### PR TITLE
Fix: ia16-elf-gcc code wrongly assumed XMS driver preserves %bx

### DIFF
--- a/include/cswap.h
+++ b/include/cswap.h
@@ -47,9 +47,14 @@ extern unsigned far *far XMSdriverAdress;
 static inline unsigned long XMSrequest(unsigned request, unsigned dx, void *si)
 {
 	long ret;
+	/* N.B. the XMS driver may clobber %bx even if the call is successful,
+	   so we need to mark %bx as clobbered.  Also include %cx, the flags,
+	   and main memory in the clobber list, for good measure.
+		-- tkchia 2018/08/24 */
 	asm volatile("lcall *%%cs:XMSdriverAdress" :
 		     "=A"(ret) :
-		     "a"(request), "d"(dx), "S"(si));
+		     "a"(request), "d"(dx), "S"(si) :
+		     "bx", "cx", "cc", "memory");
 	return ret;
 }
 #else

--- a/suppl/compat/dos.h
+++ b/suppl/compat/dos.h
@@ -42,22 +42,22 @@ extern void intr(int nr, union REGPACK *r);
 
 static inline unsigned getpsp(void)
 {
-	unsigned psp;
+	unsigned psp, scratch;
 	asm volatile("int $0x21" :
-		     "=b"(psp) :
+		     "=a"(scratch), "=b"(psp) :
 		     "Rah"((unsigned char)0x62) :
-		     "ax");
+		     "cc");
 	return psp;
 }
 #define _psp getpsp()
 
 static inline unsigned char getosmajor(void)
 {
-	unsigned char osmajor;
+	unsigned char osmajor, scratch;
 	asm volatile("int $0x21" :
-		     "=Ral"(osmajor) :
-		     "Rah"((unsigned char)0x30) :
-		     "bx", "cx");
+		     "=Ral"(osmajor), "=Rah"(scratch) :
+		     "1"((unsigned char)0x30) :
+		     "bx", "cx", "cc");
 	return osmajor;
 }
 #define _osmajor getosmajor()


### PR DESCRIPTION
This proposed patch fixes a problem which (on my machine) was causing FreeCOM compiled with `xms-swap gcc` to swap only part of the transient stack area --- rather than the whole stack --- to XMS, and back.  The bug ultimately would cause FreeCOM to crash when one tries to `EXIT` from the shell.

Thank you!