### PR TITLE
Fix: keep asm inputs & clobbers separate in gcc port of dup2

### DIFF
--- a/shell/command.c
+++ b/shell/command.c
@@ -93,8 +93,9 @@ int dup(int fd)
 
 int dup2(int oldfd, int newfd)
 {
-  asm volatile("int $0x21" :
-	       : "Rah"((char)0x46), "b"(oldfd), "c"(newfd): "ax");
+  int scratch;
+  asm volatile("int $0x21" : "=a" (scratch) :
+			     "Rah"((char)0x46), "b"(oldfd), "c"(newfd));
   return 0;
 }
 #endif


### PR DESCRIPTION
As a result of [fixing a `gcc-ia16` bug in the `asm` clobber list handling](https://github.com/tkchia/gcc-ia16/commit/7d89c99e279b44a582e5a31ebe43219fbbcae2c2), I found another place in FreeCOM where an `asm` input operand was (incorrectly) overlapping with its clobber list.  This patch should fix this.

Thank you!