### PR TITLE
ia16-elf-gcc: intr( ) now loads flags before invoking interrupt

### DIFF
--- a/suppl/src/intr.asm
+++ b/suppl/src/intr.asm
@@ -43,6 +43,8 @@ intr:		push	bp			; Standard C entry
 		mov	[cs:intr_1-1], al
 		jmp	short intr_2		; flush the instruction cache
 intr_2:		mov	bx, [bp+6]		; regpack structure
+		mov	ah, [bx+18]		; SZAPC flags
+		sahf
 		mov	ax, [bx]
 		mov	cx, [bx+4]
 		mov	dx, [bx+6]


### PR DESCRIPTION
This fixes the `[Out of memory loading STRINGS.]` problem I encountered when running FreeCOM under DOSBox 0.74, as I mentioned [on `freedos-devel`](https://www.mail-archive.com/freedos-devel@lists.sourceforge.net/msg11641.html) --- at least when FreeCOM is compiled with GCC.

I have not yet figured out how best to patch `intr( )` to load flags for the Open Watcom case.

Thank you!