### PR TITLE
Fix loadhigh failure when zero-byte free memory block is exist

### DIFF
--- a/shell/loadhigh.c
+++ b/shell/loadhigh.c
@@ -451,7 +451,7 @@ static int loadhigh_prepare(void)
     int found_one = 0;
 
     for (mcbAssign(mcb, region->start)
-     ; FP_SEG(mcb) < region->end && mcb->mcb_type == 'M'
+     ; FP_SEG(mcb) < region->end && mcb->mcb_type == 'M' && mcb->mcb_size > 0
      ; mcbNext(mcb))
     {
       if (!mcb->mcb_ownerPSP)


### PR DESCRIPTION
to reproduce the issue:

1. Create zero-byted free memory arena (in conventional or upper memory block)
2. LH some_command
3. The system will somewhat go wrong

Boot FD image for the test  : [test_zerobytes_freemem.zip](https://github.com/FDOS/freecom/files/3276728/test_zerobytes_freemem.zip)
