### PR TITLE
Allow shell to exit with the last errorlevel instead of always zero.

### DIFF
--- a/shell/command.c
+++ b/shell/command.c
@@ -935,5 +935,5 @@ int main(void)
 	kswapDeRegister(kswapContext);
 #endif
 
-  return 0;
+  return errorlevel;
 }


### PR DESCRIPTION
Allow non-permanent command.com instances to exit with the last errorlevel instead of always zero.