### PR TITLE
Add Finnish translation to FreeCOM

### DIFF
--- a/strings/FINNISH.ERR
+++ b/strings/FINNISH.ERR
@@ -1,0 +1,130 @@
+# $Id$
+#
+# Critical error national customization file
+#
+#       Language: Finnish
+#       Codepage: 850
+#       Author:   Sampo Hippel„inen
+# 
+# The critical error (criter) handler receives some information
+# from the kernel about what error condition happens, generates some
+# human friendly message from it, requests the user's opinion about
+# how to proceed and, finally, returns to the kernel.
+# 
+# The human friendly message is generated using one of the following
+# templates:
+# BLOCK_DEVICE (for criters on block devices)
+# 	Error %1 drive %A: %2 area: %3
+# -and- CHAR_DEVICE (for criters on character devices)
+# 	Error %1 device %A: %3
+# 
+# Two-character sequences, which first character is a percent sign '%',
+# are placeholders for other information:
+# %% -> a single percent sign
+# %1 -> either READ or WRITE, depending on what kind of operation
+# 	caused the criter
+# %2 -> the kind of area the criter took place on DOS, FAT, ROOT, or DATA
+# %3 -> the actual error string; these are the strings associated to
+# 	a number 0 through N, and must correspond to the number passed in
+# 	lowbyte(DI) to the criter handler (see RBIL INT-24 for details)
+# %A -> drive letter (for block devices); name of device (character devices)
+# 
+# Below the line describing the error the user is prompted for the action
+# to proceed. This line is dynamically constructed depending on which
+# action are available at all. The full line may look like this:
+# 	(A)bort, (I)gnore, (R)etry, (F)ail?_
+# 
+# The individual words are defined by ABORT, IGNORE, RETRY, FAIL. They
+# should indicate which user response keys is associated with them;
+# suggested is to use the first letter and enclose it in parenthesises.
+# The delimiter ", " can be defined with DELIMITER and is the same
+# for all slots.
+# The "? " sequence is defined by QUESTION.
+# The order of the actions is fixed and cannot be customized.
+# 
+# With each action a number of user response keys must be associated.
+# They can be enumerated with the KEYS_ABORT, KEYS_IGNORE, ...
+# strings. Because the key is searched in the same format as returned
+# by INT-16-00, both upper and lower case must be specified and
+# certain special keys cannot be used.
+# 
+# The individual error strings are defined by the #: lines, where
+# the hash sign '#' refers to the number the kernel passes to the
+# criter handler. The UNKNOWN string is displayed for all error
+# numbers not specified.
+#
+# NOTE #1: The percent rule applies to _all_ criter strings!
+# NOTE #2: Each string occupies exactly one line.
+# NOTE #3: Any leading or trailing whitespaces are removed. Prefix the
+#	first or suffix the last whitespace with '%.' (one percent sign and
+#	one dot). This sequence is removed from the string totally.
+# NOTE #4: To embed any character use: %&## (one percent sign,
+#		one ampersand and exactly two hexa-decimal digits)
+
+## Primary strings
+S2
+BLOCK_DEVICE: Virhe %1 levyn %A: %2aluetta: %3
+S3
+CHAR_DEVICE: Virhe %1 laitetta %A: %3
+
+## kind of operation
+S0
+READ: lukiessa
+S1
+WRITE: kirjoittaessa
+
+## kind of failed area of block devices
+S4
+DOS: DOS-
+S5
+FAT: FAT-
+S6
+ROOT: juuri
+S7
+DATA: tieto
+
+## action strings
+S8
+IGNORE: (O)hitus
+S9
+RETRY: (U)usinta
+S10
+ABORT: (L)opetus
+S11
+FAIL: (V)irhe
+## keys associated with the actions
+S14 (compacted)
+KEYS_IGNORE: oO
+KEYS_RETRY:  uU
+KEYS_ABORT:  lL
+KEYS_FAIL:   vV
+## embedded strings
+S12
+QUESTION:  ? %.
+S13
+DELIMITER: , %.
+
+## Error strings
+UNKNOWN: Tuntematon virhekoodi
+S15
+0: kirjoitussuojausvirhe
+1: ajuri ei tunnista yksikk”„
+2: asema ei valmis
+3: ajuri ei tunnista komentoa
+4: tietovirhe (CRC)
+5: virheellinen laiteajuripyynt”tietueen koko
+6: hakuvirhe
+7: tunnistamaton tietov„line
+8: sektoria ei l”ydy
+9: tulostimen paperi loppu
+10: kirjoitusvika
+11: lukuvika
+12: yleisvika
+13: yhteisk„ytt”virhe
+14: lukitusvirhe
+15: virheellinen levyn vaihto
+16: tiedoston ohjauslohko ei saatavilla
+17: yhteisk„ytt”puskurin ylivuoto
+18: koodisivu ei t„sm„„
+19: sy”te loppu
+20: levytila ei riit„

--- a/strings/FINNISH.LNG
+++ b/strings/FINNISH.LNG
@@ -1,0 +1,1549 @@
+# $Id$
+#
+# FreeCOM national customization file
+#
+#       Language: Finnish
+#       Codepage: 850
+#       Author:   Sampo Hippel„inen
+# 
+# This file is used to generate all the messages that command.com
+# outputs.  This file is the input to the fixstrs program, and it
+# outputs strings.h and strings.dat.  The .DAT file is appended to
+# the command.exe file, and then renamed to command.com.  The .H
+# file contains all the info for the program to retreive the
+# messages.
+#
+# The format of this file is simple.  Blank lines and lines starting
+# with "#" are ignored.
+# Each message starts with a label name that will be used to refer to
+# the message in the program.  A label starts with a colon ":".
+# A label has a version ID attached to it delimited by a hash sign, e.g.:
+#	:TEXT_LABEL#1
+# This version is incremented each time the contents of the string has
+# undergo a larger change. The same language definition may contain the
+# same label up to one time, regardless of the version. FIXSTRS compares
+# both the label and the version ID and both must match.
+# A missing version is assumed as "#0".
+# If there is a percent sign (%) appended to the version, the printf()
+# format string %-style placeholders are compared for the strings. The
+# sign need to be set in DEFAULT.LNG only.
+#
+# All lines after the label are the message until a line with a
+# single "." or "," in the first column.  The difference is the
+# period (".") signifies that there will be a final carrage return when
+# the message is displayed, but a comma does not.
+#
+# The body may contain backslash escape sequences as known from C; there
+# are the usual \# (where '#' is a lowercase letter except 'x' or one of
+# "[]{}?"), \\ (to embed a backslash itself)
+# \x?? (where '??' are up to two hexadecimal digits), \0 (to embed a NUL
+# character), \, and \. (to specify a period or comma in the first column
+# of a line) and the single \ at the end of the line to suppress to append
+# a newline character. Note: There is NO octal sequence except the short \0!
+# There is a known bug (or feature): [ignore the very first hash mark]
+#:TEXT_LABEL#2
+#
+#\
+#,
+# Although the first data line appends the newline, the second does not,
+# though the comma removes the newline from the first line.
+
+# Defining prompts
+# Some prompts may cause an user interaction. Those ones should be in sync
+# with the issued text. To define how to interprete a pressed key, they
+# are mapped into metakeys like that: [ignore first hash sign]
+
+## Return value: a -> Yes; else -> No
+#:PROMPT_YES_NO#1
+#KkEe\n\r{CBREAK}
+#aabb b b       b
+# (Yes/No) ? \
+#.
+
+# All strings, which label start with "PROMPT_", are parsed as prompts.
+# The first two lines of the body are special; the first one enumerates all
+# valid keys, the second one assigns arbitary metakeys. Metakeys may
+# range from 'a' through 'z'; spaces are ignored; everything else cause
+# an error. The comment preceeding the prompt definition associates the
+# metakeys with their meaning.
+# The remaining lines of the body contain the text to be displayed.
+#
+# Above example defines a native Yes/No prompt with a space behind the question
+# mark and no appended newline.
+# The metakey 'a' means "User answered with 'Yes'" and 'b' means no.
+# The keys 'Y' and 'y' are mapped to metakey 'a' (aka Yes) and the keys
+# 'N', 'n', Enter and ^Break are mapped to metakey 'b' (aka No).
+# The spaces between the 'b's in the second line had been inserted to
+# align them with the corresponding keys of the first line, hence in order
+# to enhance readibility of the association between the pressed keys and their
+# mapping into a metakey.
+#
+# The first line (pressed keys) has to enumerate the ASCII value as returned
+# by DOS or BIOS (INT-10); special keys normally expressed with ASCII code zero,
+# but a non-zero scancode are NOT supported; this limit includes for instance
+# the function keys F1 through F12 and the cursor keys and it is not possible
+# to differ between the number pad and normal keys.
+# The keys may be enumerated by their ASCII character, by a backslash sequence,
+# or a symbolic name enclosed in curly brackets (see FIXSTRS.C "symkeys[]"
+# array about the supported symnames).
+
+
+#
+#  These are error messages
+#
+## Issued if a single character option is unknown
+:TEXT_ERROR_INVALID_SWITCH#0%
+Virheellinen valitsin. - /%c
+.
+
+## Issued if a longname option is unknown
+:TEXT_ERROR_INVALID_LSWITCH#0%
+Virheellinen valitsin. - /%s
+.
+
+## Issued if the context, the type of argument etc. is invalid
+:TEXT_ERROR_ILLFORMED_OPTION#0%
+Virheellinen asetus: '%s'
+.
+
+:TEXT_ERROR_OPT_ARG#0%
+Valitsimelle '%s' ei kuulu olla argumenttia
+.
+
+:TEXT_ERROR_OPT_NOARG#0%
+Valitsimella '%s' pit„„ olla argumentti
+.
+
+:TEXT_INVALID_NUMBER#0%
+Virheellinen luku: '%s'
+.
+
+:TEXT_ERROR_CLOSE_QUOTE#0%
+Puuttuva loppulainausmerkki: %c
+.
+
+:TEXT_ERROR_TEMPFILE
+V„liaikaistiedoston luonti ep„onnistui
+.
+
+:TEXT_ERROR_TOO_MANY_PARAMETERS_STR#0%
+Liikaa parametreja. - '%s'
+.
+
+:TEXT_ERROR_TOO_MANY_PARAMETERS
+Liikaa parametreja.
+.
+
+:TEXT_ERROR_INVALID_PARAMETER#0%
+Virheellinen parametri. - '%s'
+.
+
+:TEXT_ERROR_PATH_NOT_FOUND
+Polkua ei l”ydy.
+.
+
+:TEXT_ERROR_FILE_NOT_FOUND
+Tiedostoa ei l”ydy.
+.
+
+:TEXT_ERROR_SFILE_NOT_FOUND#0%
+Tiedostoa ei l”ydy. - '%s'
+.
+
+:TEXT_ERROR_REQ_PARAM_MISSING#0%
+Vaadittu parametri puuttuu.
+.
+
+:TEXT_ERROR_INVALID_DRIVE#0%
+Virheellinen asema %c:.
+.
+
+:TEXT_ERROR_BADCOMMAND#2%
+Komento tai tiedostonimi tuntematon - "%s".
+.
+
+:TEXT_ERROR_OUT_OF_MEMORY
+Muisti loppu.
+.
+
+:TEXT_ERROR_OUT_OF_DOS_MEMORY#1
+DOS-muistin varausvirhe.
+.
+
+:TEXT_ERROR_CANNOTPIPE
+Putkivirhe!  V„liaikaistiedoston avaus ep„onnistui!
+.
+
+:TEXT_ERROR_LONG_LINE_BATCHFILE#0%
+Rivi #%ld komentojonossa '%s' liian pitk„.
+.
+
+:TEXT_ERROR_BFILE_VANISHED#0%
+Komentojonoa '%s' ei l”ydy.
+.
+
+:TEXT_ERROR_BFILE_LABEL#0%
+Komentojonossa '%s' ei ole nimi”t„ '%s'.
+.
+
+:TEXT_ERROR_DIRFCT_FAILED#1%
+%s '%s' ep„onnistui.
+.
+# The next three errors must remain in this order!
+:TEXT_ERROR_SET_ENV_VAR#0%
+Ei voitu asettaa ymp„rist”muuttujaa '%s'.
+Ymp„rist” t„ynn„?
+.
+:TEXT_ERROR_ENV_VAR_NOT_FOUND#0%
+Ymp„rist”muuttujaa '%s' ei l”ydy.
+.
+:TEXT_ERROR_NO_ENVIRONMENT
+Ymp„rist” puuttuu. Muisti ehk„ v„hiss„. K„yt„ /E.
+.
+
+# The next three errors must remain in this order!
+:TEXT_ERROR_SET_ALIAS#1%
+Aliasta '%s' ei voitu asettaa. Aliastila t„ynn„?
+.
+:TEXT_ERROR_ALIAS_NOT_FOUND#1%
+Aliasta '%s' ei l”ydy.
+.
+:TEXT_ERROR_NO_ALIAS_SEGMENT#1
+Ei aliastilaa. Muisti ehk„ v„hiss„.
+.
+
+:TEXT_ERROR_SYNTAX_STR#0%
+Syntaksivirhe. - '%s'
+.
+
+:TEXT_ERROR_SYNTAX
+Syntaksivirhe.
+.
+
+:TEXT_ERROR_FILENAME_TOO_LONG#0%
+Tiedostonimi liian pitk„. - '%s'
+.
+
+:TEXT_ERROR_SELFCOPY#0%
+Ei voi kopioida '%s' itseens„
+.
+
+:TEXT_ERROR_COMMAND_TOO_LONG
+Komentorivi liian pitk„ aliaslaajennuksineen!
+.
+
+:TEXT_ERROR_LINE_TOO_LONG
+Komentorivi yli 125 merkki„.
+.
+
+:TEXT_ERROR_HISTORY_SIZE#1%
+Historian koko '%s' virheellinen.
+.
+
+:TEXT_HISTORY_EMPTY#1
+Komentorivihistoria tyhj„.
+.
+
+
+:TEXT_ERROR_BAD_MCB_CHAIN
+Muistin ohjauslohkoketju virheellinen tai MS-DOS ei yhteensopiva.
+.
+
+:TEXT_ERROR_UNDEFINED_ERROR#0%
+Tuntematon virhe %d.
+.
+
+:TEXT_ERROR_REGION_WARNING#0%
+Muistialue %d virheellinen - ohitetaan.
+.
+
+:TEXT_ERROR_ON_OR_OFF
+T„ytyy olla ON tai OFF.
+.
+
+:TEXT_ERROR_BAD_VARIABLE
+Muuttujan m„„rittely virheellinen.
+.
+
+:TEXT_ERROR_IN_MISSING#1
+FOR: IN puuttuu.
+.
+
+:TEXT_ERROR_MISSING_PARENTHESES#1
+Sulku tai molemmat sulut puuttuu.
+.
+
+:TEXT_ERROR_DO_MISSING#1
+FOR: DO puuttuu.
+.
+
+:TEXT_ERROR_NO_COMMAND_AFTER_DO#1
+FOR: komento puuttuu DO:n j„lkeen.
+.
+
+:TEXT_ERROR_REDIRECT_FROM_FILE#0%
+Sy”tett„ ei voi ohjata tiedostosta '%s'.
+.
+
+:TEXT_ERROR_REDIRECT_TO_FILE#0%
+Tulostetta ei voi ohjata tiedostoon '%s'.
+.
+
+:TEXT_ERROR_EMPTY_REDIRECTION#1
+Tyhj„ ohjaus.
+.
+
+:TEXT_ERROR_INVALID_DATE
+Virheellinen p„iv„m„„r„.
+.
+
+:TEXT_ERROR_INVALID_TIME
+Virheellinen aika.
+.
+
+:TEXT_ERROR_NO_GOTO_LABEL
+GOTO:lle ei m„„ritelty nimi”t„.
+.
+
+:TEXT_CTTY_NOTIMPLEMENTED
+T„m„ COMMAND.COM-versio ei toteuta CTTY-komentoa.
+.
+
+:TEXT_ERROR_NORW_DEVICE#0%
+Puuttuva tai virheellinen siirr„nt„laite '%s'.
+.
+
+:TEXT_ERROR_CTTY_DUP#0%
+TTY:n '%s' tiedostokuvaajaa ei voitu muuttaa.
+.
+
+:TEXT_ERROR_L_NOTIMPLEMENTED
+/L ei viel„ toteutettu.
+.
+
+:TEXT_ERROR_U_NOTIMPLEMENTED
+/U ei viel„ toteutettu.
+.
+
+:TEXT_ERROR_WRITING_DEST
+Kirjoitus kohteeseen ep„onnistui.
+.
+
+:TEXT_ERROR_CANNOT_OPEN_SOURCE#0%
+L„hteen avaus ep„onnistui. - '%s'
+.
+
+:TEXT_ERROR_OPEN_FILE#0%
+Ei voitu avata tiedostoa '%s'
+.
+
+:TEXT_ERROR_READ_FILE#0%
+Ei voitu lukea tiedostosta '%s'
+.
+
+:TEXT_ERROR_WRITE_FILE#0%
+Ei voitu kirjoittaa tiedostoon '%s'
+.
+
+:TEXT_ERROR_LEADING_PLUS
+Yhdistysmerkki '+' ei voi olla argumenttien edell„.
+.
+
+:TEXT_ERROR_TRAILING_PLUS
+Yhdistysmerkki '+' ei voi olla argumenttien j„lkeen.
+.
+
+:TEXT_ERROR_NOTHING_TO_DO
+Ei teht„v„„.
+.
+
+:TEXT_ERROR_COPY
+COPY ep„onnistui
+.
+
+:TEXT_ERROR_IF_EXIST_NO_FILENAME#1
+IF EXIST: tiedostonimi puuttuu
+.
+:TEXT_ERROR_IF_ERRORLEVEL_NO_NUMBER#1
+IF ERRORLEVEL: luku puuttuu
+.
+:TEXT_ERROR_IF_ERRORLEVEL_INVALID_NUMBER#1
+IF ERRORLEVEL: luku virheellinen
+.
+:TEXT_ERROR_IF_MISSING_COMMAND#1
+IF: komento puuttuu
+.
+
+:TEXT_NOT_IMPLEMENTED_YET
+Ei viel„ toteutettu... pahoittelemme.
+.
+
+:TEXT_FAILED_LOAD_STRINGS
+Ei voitu ladata viestej„ muistiin.
+.
+
+:TEXT_MSG_NOTIMPLEMENTED
+T„m„ COMMAND.COM ei toteuta /MSG-valitsinta.
+.
+
+:TEXT_MSG_ITEMS_DISPLAYED#1%
+%u kohdetta.
+.
+
+:TEXT_CORRUPT_COMMAND_LINE
+Komentorivi vioittunut. Sis„inen virhe. Johtuu j„rjestelm„st„,
+jolla COMMAND.COM:ia ajetaan. Ilmoita t„st„ virheest„, kiitos.
+.
+
+:TEXT_QUOTED_C_OR_K#1
+/C ja /K -valitsimet eiv„t tue lainausmerkkej„, ohitetaan.
+.
+
+:TEXT_INIT_FULLY_QUALIFIED#1%
+COMMAND.COM:in polku tulee olla t„ysin m„„ritelty!
+Sen tulee sis„lt„„ aseman kirjain ja alkaa kenoviivalla.
+Esimerkki: C:\\FDOS
+
+COMMAND.COM olettaa polun nyt olevan:
+%s
+.
+
+:TEXT_ERROR_RESTORE_SESSION
+Istuntotietoa ei voitu palauttaa. Paikalliset asetukset
+menetet„„n. Yll„ olevat virheviestit kuvaavat ongelmaa.
+.
+
+:TEXT_ERROR_SAVE_SESSION
+Nykyist„ tietoa ei voida s„ilytt„„ ohjelmaa kutsuessa.
+Yll„ olevat virheviestit kuvaavat ongelmaa.
+.
+
+:TEXT_ERROR_CWD_FAILED#1%
+Asema %c: ei vastaa.
+.
+
+:TEXT_ERROR_KSWAP_ALIAS_SIZE
+Heittovaihto ep„onnistui: aliakset viev„t liikaa muistia.
+.
+
+
+:TEXT_ERROR_KSWAP_ALLOCMEM
+Heittovaihto ep„onnistui: et„muistin varaus ep„onnistui.
+.
+
+:TEXT_ERROR_ALIAS_OUT_OF_MEM#1
+Aliastila loppu.
+.
+
+:TEXT_ERROR_ALIAS_NO_SUCH#1%
+Ei aliasta: '%s'
+.
+
+:TEXT_ERROR_ALIAS_INSERT#1
+Aliaksen lis„ys ep„onnistui.
+.
+
+:TEXT_ALIAS_INVALID_NAME#1%
+Aliaksen nimi '%s' virheellinen.
+.
+
+:TEXT_ERROR_LOADING_CONTEXT#1
+Kontekstimoduulin tai virheenk„sittelij„n latausvirhe.
+.
+
+:TEXT_ERROR_CONTEXT_OUT_OF_MEMORY#1
+Kontekstilta loppui muisti.
+Jos virhe toistuu, harkitse sis„isen puskurin tilan kasvatusta,
+kuten historian, hakemistopinon, tms.
+.
+
+:TEXT_ERROR_CONTEXT_LENGTH#1%
+Kontekstin yhteiskoko %lu tavua ylitt„„ enimm„israjan.
+Kooksi asetetaan %u tavua.
+.
+
+:TEXT_ERROR_CONTEXT_ADD_STATUS#1
+Tilatiedon lukeminen kontekstiin ep„onnistui. Virhe voi johtua
+muistin vioittumisesta tai kontekstin v„himm„iskoon v„„rin
+m„„rittelyst„. Ilmoitathan FreeCOM:n yll„pit„j„lle:
+freecom@freedos.org
+.
+
+:TEXT_ERROR_CONTEXT_AFTER_SWAP#1
+Konteksti puuttuu heittovaihdon j„lkeen. Se luodaan uudelleen,
+mutta aliakset ym. menetet„„n.
+.
+
+:TEXT_ERROR_PERMISSION_DENIED#1%
+%s: P„„sy ev„tty
+.
+
+:TEXT_ERROR_NO_SUCH_FILE#1%
+%s: Tiedostoa tai hakemistoa ei l”ydy
+.
+
+:TEXT_ERROR_UNKNOWN_ERROR#1%
+%s: Tuntematon virhe
+.
+
+#
+# Informational messages
+#
+
+:TEXT_MSG_PAUSE#1
+Paina mit„ tahansa n„pp„int„ jatkaaksesi . . .\
+.
+
+:TEXT_MSG_HISTORY_SIZE#0%
+Historian koko %d tavua.
+.
+
+:TEXT_MSG_DOSKEY
+DOSKEY on jo k„yt”ss„ t„ss„ kehotteessa.
+.
+
+:TEXT_MSG_ECHO_STATE#0%
+ECHO on %s
+.
+
+:TEXT_MSG_VERIFY_STATE#0%
+VERIFY on %s
+.
+
+:TEXT_MSG_FDDEBUG_STATE#0%
+DEBUG-tuloste on %s.
+.
+:TEXT_MSG_FDDEBUG_TARGET#0%
+DEBUG-tuloste sijaintiin '%s'.
+.
+
+:TEXT_MSG_BREAK_STATE#0%
+BREAK on %s
+.
+
+:TEXT_MSG_LFNFOR_STATE#0%
+LFNFOR on %s
+.
+
+:TEXT_MSG_LFNFOR_COMPLETE_STATE#0%
+LFN-t„ydennys on %s
+.
+
+:TEXT_MSG_CURRENT_DATE#0%
+P„iv„m„„r„ nyt on %s
+.
+
+## The three DATE prompts MUST be in this order!
+:TEXT_MSG_ENTER_DATE_AMERICAN#1%
+Sy”t„ uusi p„iv„m„„r„ (kk%spp%s[vv]vv): \
+.
+:TEXT_MSG_ENTER_DATE_EUROPE#1%
+Sy”t„ uusi p„iv„m„„r„ (pp%skk%s[vv]vv): \
+.
+:TEXT_MSG_ENTER_DATE_JAPANESE#1%
+Sy”t„ uusi p„iv„m„„r„ ([vv]vv%skk%spp): \
+.
+
+:TEXT_MSG_CURRENT_TIME#0%
+Aika nyt on %s
+.
+
+:TEXT_STRING_PM#1
+ ip.\
+.
+:TEXT_STRING_AM#1
+ ap.\
+.
+
+:TEXT_MSG_ENTER_TIME#1
+Sy”t„ uusi aika: \
+.
+
+# src-file <operation> target-file
+:TEXT_MSG_COPYING#0%
+%s %s %s
+.
+
+# This prompt MUST include the pseudo key CBREAK!
+# Note: This prompt ignores DOS NLS intentionally in order to
+# keep interactive prompt & user-interaction in sync.
+# Used by Delete all (K/E) --> let ENTER default to NO
+# Return value: a -> Yes; else -> No
+:PROMPT_DELETE_ALL#1%
+KkEe{CR}{LF}{CBREAK}
+aabb   b   b       b
+Kaikki tiedostot sijainnissa '%s' poistetaan!
+Oletko varma (K/E)? \
+.
+
+# This prompt MUST include the pseudo key CBREAK!
+# Note: This prompt ignores DOS NLS intentionally in order to
+# keep interactive prompt & user-interaction in sync.
+# Return value: a -> Yes; else -> No
+:PROMPT_YES_NO#1
+KkEe{LF}{CR}{CBREAK}{ESC}
+aabb   a   a       b    b
+ [Kyll„=ENTER, Ei=ESC] ? \
+.
+
+# This prompt MUST include the pseudo key CBREAK!
+# Note: This prompt ignores DOS NLS intentionally in order to
+# keep interactive prompt & user-interaction in sync.
+# Attention: This prompt is issued via BIOS; any newline MUST be prefixed
+#	by \r!
+# Return value: a -> Yes; b -> No; c -> All; else -> Undefined
+:PROMPT_CANCEL_BATCH#1%
+KkEeAaLl{LF}{CR}{CBREAK}{ESC}
+aabbcccc   a   a       c    b
+Control-Break painettu.\r
+Lopetetaanko komentojono '%s' (Kyll„/Ei/kAikki) ? \
+.
+
+# This prompt MUST include the pseudo key CBREAK!
+# Note: This prompt ignores DOS NLS intentionally in order to
+# keep interactive prompt & user-interaction in sync.
+# Return value: a -> Yes; b -> No; c -> All; d -> Quit
+:PROMPT_OVERWRITE_FILE#1%
+KkEeAaLl{BREAK}{ENTER}{ESC}
+aabbccdd      d      a    b
+Korvataanko '%s' (Kyll„/Ei/kAikki/Lopeta) ? \
+.
+
+# This prompt MUST include the pseudo key CBREAK!
+# Note: This prompt ignores DOS NLS intentionally in order to
+# keep interactive prompt & user-interaction in sync.
+# Return value: a -> Yes; b -> No; c -> All; d -> Quit
+:PROMPT_APPEND_FILE#1%
+KkEeAaLl{BREAK}{ENTER}{ESC}
+aabbccdd      d      a    b
+Lis„t„„nk” tiedoston '%s' loppuun (Kyll„/Ei/kAikki/Lopeta) ? \
+.
+
+# This prompt MUST include the pseudo key CBREAK!
+# Note: This prompt ignores DOS NLS intentionally in order to
+# keep interactive prompt & user-interaction in sync.
+# Return value: a -> Yes; b -> No; c -> All; d -> Quit
+:PROMPT_DELETE_FILE#1%
+KkEeAaLl{BREAK}{ENTER}{ESC}
+aabbccdd      d      a    b
+Poistetaanko '%s' (Kyll„/Ei/kAikki/Lopeta) ? \
+.
+
+:TEXT_UNKNOWN_FILENAME#1
+<<tuntematon>>\
+.
+
+:TEXT_DIRSTACK_EMPTY
+Hakemistopino tyhj„.
+.
+
+## Strings to construct the DIR output
+:TEXT_DIR_HDR_VOLUME#1%
+ Taltio asemassa %c \
+.
+:TEXT_DIR_HDR_VOLUME_STRING#0%
+on %s
+.
+:TEXT_DIR_HDR_VOLUME_NONE
+nimet”n
+.
+:TEXT_DIR_HDR_SERIAL_NUMBER#0%
+ Taltion sarjanumero on %04X-%04X
+.
+:TEXT_DIR_FTR_FILES#1%
+%10s tiedosto(a)\
+.
+:TEXT_DIR_FTR_BYTES#0%
+   %12s tavua
+.
+:TEXT_DIR_FTR_TOTAL_NUMBER
+Yhteens„ lueteltu:
+.
+:TEXT_DIR_FTR_DIRS#1%
+%10s hakemisto(a)\
+.
+:TEXT_DIR_FTR_BYTES_FREE#0%
+%15s tavua vapaana
+.
+:TEXT_DIR_DIRECTORY#0%
+Hakemisto: %s
+.
+:TEXT_DIR_DIRECTORY_WITH_SPACE#0%
+ Hakemisto: %s
+.
+:TEXT_DIR_LINE_FILENAME_WIDE#1%
+%-15s\
+.
+:TEXT_DIR_LINE_FILENAME_BARE#1%
+%s
+.
+:TEXT_DIR_LINE_FILENAME_SINGLE#1%
+%-13s\
+.
+:TEXT_DIR_LINE_FILENAME#1%
+%-8s %-3s \
+.
+:TEXT_DIR_LINE_SIZE_DIR#1
+        <HAK> \
+.
+:TEXT_DIR_LINE_SIZE#1%
+   %10s \
+.
+
+:TEXT_FILE_COMPLATION_DISPLAY#1%
+%-14s\
+.
+
+:TEXT_MSG_PATH#0%
+PATH=%s
+.
+:TEXT_MSG_PATH_NONE#1
+Hakupolkua ei m„„ritelty.
+.
+
+## The following names MUST be in this order!
+:TEXT_WEEKDAY_SHORT_NAME_SUNDAY#1
+su\
+.
+:TEXT_WEEKDAY_SHORT_NAME_MONDAY#1
+ma\
+.
+:TEXT_WEEKDAY_SHORT_NAME_TUESDAY#1
+ti\
+.
+:TEXT_WEEKDAY_SHORT_NAME_WEDNSDAY#1
+ke\
+.
+:TEXT_WEEKDAY_SHORT_NAME_THURSDAY#1
+to\
+.
+:TEXT_WEEKDAY_SHORT_NAME_FRIDAY#1
+pe\
+.
+:TEXT_WEEKDAY_SHORT_NAME_SATURDAY#1
+la\
+.
+
+# Displayed by DEL how many files were removed.
+# These three strings must be kept in order!
+:TEXT_MSG_DEL_CNT_FILES#1
+mit„„n ei poistettu.
+.
+:TEXT_MSG_DEL_CNT_FILES_1#1
+yksi tiedosto poistettu.
+.
+:TEXT_MSG_DEL_CNT_FILES_2#1%
+%u tiedostoa poistettu.
+.
+
+:TEXT_MSG_SHOWCMD_INTERNAL_COMMANDS
+Saatavilla olevat sis„iset komennot:
+.
+
+:TEXT_MSG_SHOWCMD_FEATURES
+
+Saatavilla olevat toiminnallisuudet:
+.
+
+## Displayed within "?" <-> showcmd() to enumerate the included features
+## Note the trailing single space
+:TEXT_SHOWCMD_FEATURE_ALIASES#1
+[aliakset] \
+.
+:TEXT_SHOWCMD_FEATURE_ENHANCED_INPUT#1
+[paranneltu sy”te] \
+.
+:TEXT_SHOWCMD_FEATURE_HISTORY#1
+[historia] \
+.
+:TEXT_SHOWCMD_FEATURE_FILENAME_COMPLETION#1
+[tiedostonimen t„ydennys] \
+.
+:TEXT_SHOWCMD_FEATURE_SWAP_EXEC#1
+[heittovaihto] \
+.
+:TEXT_SHOWCMD_FEATURE_CALL_LOGGING#1
+[k„ynnistysloki] \
+.
+:TEXT_SHOWCMD_FEATURE_LAST_DIR#1
+[viime hakemisto] \
+.
+:TEXT_SHOWCMD_FEATURE_LONG_FILENAMES#1
+[pitk„t tiedostonimet] \
+.
+:TEXT_SHOWCMD_FEATURE_KERNEL_SWAP_SHELL#1
+[ytimen heittovaihto] \
+.
+:TEXT_SHOWCMD_FEATURE_XMS_SWAP#1
+[XMS-heittovaihto] \
+.
+:TEXT_SHOWCMD_DEFAULT_TO_SWAP#1
+[heittovaihto oletuksena] \
+.
+:TEXT_SHOWCMD_FEATURE_INSTALLABLE_COMMANDS#1
+[asennettavat komennot] \
+.
+:TEXT_SHOWCMD_FEATURE_NLS#1
+[DOS NLS] \
+.
+:TEXT_SHOWCMD_FEATURE_DIRSTACK#1
+[hakemistopino (PUSHD)] \
+.
+:TEXT_SHOWCMD_FEATURE_DEBUG#1
+[FreeCOM-virheenkorjaus] \
+.
+
+:TEXT_MSG_INIT_BYPASS_AUTOEXEC#1
+
+F8 k„ynnist„„ j„ljitystilan, F5 ohittaa %s... \
+.
+:TEXT_MSG_INIT_BYPASSING_AUTOEXEC#0%
+Ohitetaan '%s'.
+.
+
+:TEXT_MSG_VER_DOS_VERSION#0%
+DOS-versio %u.%u
+.
+
+:TEXT_MSG_VER_EARLY_FREEDOS
+FreeDOS-ydin (koontiversio 1933 tai vanhempi)
+.
+
+:TEXT_MSG_VER_LATER_FREEDOS#0%
+FreeDOS-ydin versio %d.%d.%d
+.
+
+
+:TEXT_MSG_VER_WARRANTY
+(C) 1994-2005 Tim Norman ja muut.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+Vikailmoitukset (englanniksi) osoitteeseen
+freedos-freecom@lists.sourceforge.net.
+P„ivitykset osoitteesta http://freedos.sourceforge.net/freecom
+.
+
+:TEXT_MSG_VER_REDISTRIBUTION
+(C) 1994-2005 Tim Norman ja muut.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+Vikailmoitukset (englanniksi) osoitteeseen
+freedos-freecom@lists.sourceforge.net.
+P„ivitykset osoitteesta http://freedos.sourceforge.net/freecom
+.
+
+:TEXT_MSG_VER_DEVELOPERS
+
+FreeDOS-komentokehotteella on ollut monta kehitt„j„„, ks.
+sis„llytetty HISTORY.TXT-tiedosto.
+
+T„ll„ hetkell„ yll„pit„j„n„ Steffen Kaiser mailto:freecom@freedos.org
+
+Vikailmoitukset (englanniksi) osoitteeseen
+freedos-freecom@lists.sourceforge.net.
+P„ivitykset osoitteesta http://freedos.sourceforge.net/freecom
+.
+
+
+# Displayed when the shell is to terminate, but has been started
+# with /P option <-> shell cannot exist;
+# This is a crash situation, because FreeCOM won't reach this situation
+# normally otherwise
+# All newlines must be prefixed by \r's !
+:TEXT_MSG_REBOOT_NOW#1
+\r\n\r
+Komentokehote on sulkeutumassa, mutta sen ei pit„isi\r
+(yleens„ "/P"-valitsimen takia).\r
+K„ynnist„ j„rjestelm„ uudelleen, tai jos kehote on moniajo-\r
+ymp„rist”ss„, lopeta t„m„ teht„v„ tai prosessi manuaalisesti.\r
+.
+
+# Displayed during the initialization phase of FreeCOM, if its own
+# filename could not be determined.
+:TEXT_MSG_FREECOM_NOT_FOUND#1
+FreeCOM-ohjelmaa ei l”ydy.
+COMMAND.COM:n koko polku tulee m„„ritt„„ COMMAND:n
+ensimm„iseksi argumentiksi, esimerkiksi:
+C:\\FDOS
+.
+
+
+:TEXT_MEMORY_ENVIRONMENT#1%
+Ymp„rist”segmentti     : maks. %5u tavua; vapaa %5u tavua
+.
+:TEXT_MEMORY_CONTEXT#1%
+Kontekstisegmentti     : maks. %5u tavua; vapaa %5u tavua
+.	
+:TEXT_MEMORY_HEAP#1%
+Keko                   : %5lu tavua vapaana
+.
+:TEXT_MEMORY_CTXT_ALIAS#1%
+\tAliakset       : raja %5u tavua, nyk. %5u tavua, %5u kohdetta
+.
+:TEXT_MEMORY_CTXT_HISTORY#1%
+\tHistoria       : raja %5u tavua, nyk. %5u tavua, %5u kohdetta
+.
+:TEXT_MEMORY_CTXT_DIRSTACK#1%
+\tHakemistopino  : raja %5u tavua, nyk. %5u tavua, %5u kohdetta
+.
+:TEXT_MEMORY_CTXT_LASTDIR#1%
+\tViime hak. -VM : k„yt. %5u tavua, %5u kohdetta
+.
+:TEXT_MEMORY_CTXT_BATCH#1%
+\tKJ-sis„kk„isyys: k„yt. %5u tavua, %5u kohdetta
+.
+:TEXT_MEMORY_CTXT_SWAPINFO#1%
+\tHV-tiedot      : k„yt. %5u tavua, %5u kohdetta
+.
+
+
+## CHCP
+:TEXT_ERROR_GET_CODEPAGE#1
+Nykyist„ koodisivua ei voitu m„„ritt„„.
+.
+:TEXT_ERROR_SET_CODEPAGE#1
+Koodisivua ei voitu vaihtaa.
+.
+:TEXT_DISPLAY_CODEPAGE#1%
+Nykyinen koodisivu on: %u.
+J„rjestelm„n (oikea) koodisivu on: %u.
+.
+
+#
+# Command help text
+#
+
+:TEXT_CMDHELP_ALIAS
+N„ytt„„, asettaa tai poistaa aliaksia.
+
+ALIAS [muuttuja[=][merkkijono]]
+
+	muuttuja    M„„ritt„„ aliaksen nimen.
+	merkkijono  M„„ritt„„ aliaksen merkkijonon.
+
+
+ALIAS ilman parametreja n„ytt„„ nykyiset aliakset.
+.
+
+:TEXT_CMDHELP_BEEP
+Soittaa merkki„„nen.
+.
+
+:TEXT_CMDHELP_BREAK
+Ottaa k„ytt””n tai poistaa k„yt”st„ laajennetun Ctrl+C-tarkistuksen.
+
+BREAK [ON | OFF]
+
+BREAK ilman parametreja n„ytt„„ nykyisen BREAK-tilan.
+.
+
+:TEXT_CMDHELP_CALL#1
+Kutsuu komentojonoa toisesta komentojonosta.
+
+CALL [/S | /N] [/Y] [asema:][polku]tiedostonimi [parametrit]
+
+  parametrit   M„„ritt„„ kutsuttavan komentojonon vaatimat
+               komentojonoparametrit.
+  /S pakottaa ja /N est„„ FreeCOM:n heittovaihdon.
+  /Y ottaa j„ljitystilan k„ytt””n kutsutulle komentojonolle.
+.
+
+:TEXT_CMDHELP_CD
+N„ytt„„ nykyisen hakemiston nimen tai vaihtaa hakemistoa.
+
+CHDIR [asema:][polku]
+CHDIR[..]
+CD [asema:][polku]
+CD[..]
+CD -
+
+  ..   Siirtyy yl„hakemistoon.
+  -    Jos "viime hakemisto" on k„yt”ss„, vaihtaa viime hakemistoon.
+
+CD asema: n„ytt„„ m„„ritetyn aseman nykyisen hakemiston.
+CD ilman parametreja n„ytt„„ nykyisen aseman ja hakemiston.
+Katso my”s: CDD
+.
+
+:TEXT_CMDHELP_CDD
+N„ytt„„ nykyisen aseman sek„ hakemiston tai vaihtaa asemaa sek„ hakemistoa.
+
+CDD [asema:][polku]
+CDD[..]
+
+  ..   Siirtyy yl„hakemistoon.
+  -    Jos "viime hakemisto" on k„yt”ss„, vaihtaa viime hakemistoon.
+
+Jos asema: m„„ritet„„n, nykyist„ asemaa vaihdetaan;
+t„m„ on ainoa ero "CHDIR"-komentoon.
+CDD ilman parametreja n„ytt„„ nykyisen aseman ja hakemiston.
+.
+
+:TEXT_CMDHELP_CHCP
+N„ytt„„ nykyisen koodisivun numeron tai vaihtaa koodisivua.
+
+CHCP [nnn]
+
+  nnn   M„„ritt„„ koodisivun numeron.
+
+CHCP ilman parametreja n„ytt„„ nykyisen koodisivun numeron.
+.
+
+:TEXT_CMDHELP_CLS
+Tyhjent„„ kuvaruudun.
+
+CLS
+.
+
+:TEXT_CMDHELP_COMMAND
+Aloittaa uuden FreeDOS-komentokehotteen.
+
+COMMAND [[asema:]polku] [laite] [/E:nnnnn] [/L:nnnn] [/U:nnn] [/P] [/MSG]
+                       [/LOW] [/Y [/[C|K] komento]]
+  [asema:]polku    M„„ritt„„ COMMAND.COM-ohjelman sijainnin.
+  laite           Asettaa k„ytett„v„n sy”te- ja tulostelaitteen.
+  /E:nnnnn        Asettaa ymp„rist”n aloituskoon olemaan nnnnn tavua.
+                  (nnnnn on oltava 256 ja 32 768 v„lilt„).
+  /L:nnnn         Asettaa sis„isen puskurin koon (vaatii /P-valitsimen).
+                  (nnnnn on oltava 128 ja 1 024 v„lilt„).
+  /U:nnn          Asettaa sy”tepuskurin koon (vaatii /P-valitsimen).
+                  (nnnnn on oltava 128 ja 255 v„lilt„).
+  /P              Tekee kehotteesta pysyv„n (est„„ lopettamisen).
+  /MSG            S„il”” virheviestit muistiin (vaatii /P-valitsimen).
+  /LOW            Pakottaa komentokehotteen pit„m„„n muistiaan
+                  alamuistissa.
+  /Y              Suorittaa /C tai /K-valitsimen komentojonon vaiheittain.
+  /C komento      Suorittaa annetun komennon ja lopettaa.
+  /K komento      Suorittaa annetun komennon ja jatkaa suoritusta.
+.
+
+:TEXT_CMDHELP_COPY
+Kopioi yhden tai useamman tiedoston eri sijaintiin.
+
+COPY [/A | /B] l„hde [/A | /B] [+ l„hde [/A | /B] [+ ...]] [kohde
+  [/A | /B]] [/V] [/Y | /-Y]
+
+  l„hde        M„„ritt„„ kopioitavat tiedostot.
+  /A           Ilmaisee, ett„ kyseess„ on ASCII-tekstitiedosto.
+  /B           Ilmaisee, ett„ kyseess„ on bin„„ritiedosto.
+  kohde        M„„ritt„„ tiedostojen uuden sijainnin ja/tai uudet nimet.
+  /V           Tarkistaa, ett„ tiedostot kirjoitetaan oikein.
+  /Y           Est„„ korvauskehotteen ja korvaa kaikki jo olemassa olevat
+               kohdetiedostot l„hdetiedostoilla.
+  /-Y          Kysyy kehotteella jokaiselle tiedostolle erikseen,
+               tulisiko jo olemassa oleva kohdetiedosto korvata.
+
+COPYCMD-ymp„rist”muuttuja saattaa m„„ritell„ /Y-valitsimen.
+Jos t„m„ asetus halutaan ohittaa, k„yt„ valitsinta /-Y.
+
+Jos haluat liitt„„ tiedostoja yhteen, m„„rit„ kohteeksi yksi tiedosto ja
+l„hteeksi useampi (yleismerkeill„ tai esimerkiksi tiedosto1+tiedosto2).
+.
+
+:TEXT_CMDHELP_CTTY
+Vaihtaa j„rjestelm„„ ohjaavaa p„„telaitetta.
+
+CTTY laite
+
+  laite    Haluamasi p„„telaite, kuten COM1.
+.
+
+:TEXT_CMDHELP_DATE#1
+N„ytt„„ tai asettaa p„iv„m„„r„n.
+
+DATE [/D] [date]
+
+DATE ilman parametreja tuo n„ytt””n nykyisen p„iv„m„„r„n ja kehotteen
+uudesta p„iv„m„„r„st„. Paina ENTER pit„„ksesi saman p„iv„m„„r„n.
+
+/D est„„ komentoa esitt„m„st„ kehotteita.
+.
+
+:TEXT_CMDHELP_DEL#2
+Poistaa yhden tai useamman tiedoston.
+
+DEL [asema:][polku]tiedostonimi [/P] [/V]
+ERASE [asema:][polku]tiedostonimi [/P] [/V]
+
+  [asema:][polku]tiedostonimi  M„„ritt„„ poistettavat tiedostot. Useamman
+                          tiedoston voi m„„ritt„„ yleismerkeill„.
+  /P	Varmistaa kehotteella ennen jokaisen tiedoston poistoa.
+  /V	N„ytt„„ kaikki poistetut tiedot.
+.
+
+:TEXT_CMDHELP_DIR#4
+N„ytt„„ hakemistossa olevat tiedostot ja alihakemistot.
+
+DIR [asema:][polku][tiedostonimi] [/P] [/W] [/A[[:]m„„ritteet]]
+  [/O[[:]j„rjestys]] [/S] [/B] [/L] [/V]
+
+  [asema:][polku][tiedostonimi]
+            M„„ritt„„ aseman, hakemiston ja/tai lueteltavat tiedostot.
+            (Voi olla laajennettu m„„rittely tai monta m„„rittely„.)
+ /P         Tauko jokaisen ruudullisen j„lkeen.
+ /W         K„ytt„„ leve„„ luettelomuotoa.
+ /A         N„ytt„„ tiedostot, joilla on tietyt m„„ritteet. (Oletus /ADHSRA)
+ m„„ritteet  D  Hakemistot                 R  Vain luku -tiedostot
+             H  Piilotiedostot             A  Arkistoitavat tiedostot
+             S  J„rjestelm„tiedostot       -  K„„nteinen („l„ n„yt„, etuliite)
+ /O         Luettelee tiedostot annetussa j„rjestyksess„.
+ j„rjestys   N  Nimen mukaan (aakkosj„rj.) S  Koon mukaan (pienin ensin)
+             E  Tiedostop„„tteen mukaan    D  Vanhimmasta uusimpaan
+             G  Hakemistot ensin           -  K„„nteinen j„rjestys (etuliite)
+             U  Žl„ lajittele		   Oletuksena /ONG
+ /S         Luettelee my”s alihakemistoissa olevat tiedostot.
+ /B         K„ytt„„ pelkistetty„ muotoa (ei otsaketietoa tai yhteenvetoa).
+ /L         K„ytt„„ pieni„ kirjaimia.
+ /Y or /4   N„ytt„„ vuosiluvun nelinumeroisena.
+
+DIRCMD-ymp„rist”muuttuja saattaa m„„ritell„ valitsimia. Ne voidaan
+poistaa k„yt”st„ sijoittamalla - (v„liviiva) ennen valitsinta, kuten /-W.
+.
+
+:TEXT_CMDHELP_DOSKEY#1
+Ulkoinen DOSKEY-ty”kalu on otettu osaksi FreeCOM:ia.
+Yl„- ja alanuolin„pp„imet selaavat historiaa ja HISTORY n„ytt„„ sen.
+Vasemmat ja oikeat nuolin„pp„imet sek„ HOME ja END siirtyv„t
+komentorivin sis„ll„ ja INSERT vaihtaa p„„llekirjoitus- ja lis„ystilan
+v„lill„. Sarkainn„pp„in t„ydent„„ nykyisen sanan tiedostonimen„;
+kahdesti painettuna se n„ytt„„ luettelon l”ydetyist„ tiedostonimist„.
+.
+
+:TEXT_CMDHELP_ORIGINAL_DOSKEY#1
+Muokkaa komentorivej„, muistaa niit„ ja luo makroja
+
+DOSKEY [/valitsin ...] [makro=[teksti]]
+
+  /BUFSIZE:koko   Asettaa makro- ja komentopuskurin koon         (oletus:512)
+  /ECHO:on|off    M„„ritt„„ makrolaajennusten kaiutustilan       (oletus:on)
+  /FILE:tiedosto  M„„ritt„„ makroja sis„lt„v„n tiedoston
+  /HISTORY        N„ytt„„ kaikki muistissa olevat komennot
+  /INSERT         Uusien merkkien lis„ys riville kirjoittaessa
+  /KEYSIZE:koko   Asettaa n„pp„imist”n n„pp„ilypuskurin koon     (oletus:15)
+  /LINE:koko      Asettaa rivin muokkauspuskurin enimm„iskoon    (oletus:128)
+  /MACROS         N„ytt„„ kaikki DOSKey-makrot
+  /OVERSTRIKE     Kirjoitus rivill„ olevien merkkien p„„lle      (oletus)
+  /REINSTALL      Asentaa DOSKey:n uudelleen muistiin
+  makro           M„„ritt„„ luotavan makron nimen
+  teksti          M„„ritt„„ makroon kuuluvat komennot
+
+ YL™S,ALAS-nuolin„pp„imet k„yv„t historiaa l„pi
+       Esc tyhjent„„ komentorivin
+        F7 n„ytt„„ komentohistorian
+    Alt+F7 tyhjent„„ komentohistorian
+[teksti]F8 hakee tekstill„ alkavaa komentoa
+        F9 hakee komentoa numerolla
+   Alt+F10 poistaa kaikki makrot
+
+Seuraavia erityiskoodeja voi k„ytt„„ DOSKeyn makrojen m„„ritelmiss„:
+  $T     Komentoerotin: makroissa voi olla useampi komento
+  $1-$9  Parametrit: toimivat samoin kuin %1-%9 komentojonoissa
+  $*     Korvautuu tekstill„, joka on makron nimen j„lkeen komennossa
+.
+
+:TEXT_CMDHELP_ECHO
+N„ytt„„ viestej„ tai kytkee komentokaiutuksen p„„lle tai pois.
+
+  ECHO [ON | OFF]
+  ECHO [viesti]
+
+ECHO ilman parametreja n„ytt„„ nykyisen komentokaiutustilan.
+.
+
+:TEXT_CMDHELP_EXIT
+Lopettaa FreeDOS-komentokehotteen, ellei /P-valitsinta ole k„ytetty.
+
+EXIT
+.
+
+:TEXT_CMDHELP_FOR
+Suorittaa komennon jokaiselle tiedostolle tiedostoryhm„ss„.
+
+FOR %muuttuja IN (ryhm„) DO komento [komento-parametrit]
+
+  %muuttuja  M„„ritt„„ tiedostomuuttujan nimen.
+  (ryhm„)    M„„ritt„„ ryhm„n tiedostoja, yleismerkit sallittu.
+  komento    M„„ritt„„ suoritettavan komennon.
+  komento-parametrit
+             M„„ritt„„ komennon parametrit.
+
+Komentojonoissa FOR-komennon muuttuja on m„„ritelt„v„ kahdella
+prosenttimerkill„, kuten %%muuttuja eik„ %muuttuja.
+
+Esimerkiksi:
+  FOR %f IN (---start--- a*.* ---end---) DO ECHO - %f -
+.
+
+:TEXT_CMDHELP_GOTO
+Siirt„„ komentojonon suorituksen annetun nimi”n kohdalle.
+
+GOTO nimi”
+
+  nimi”   M„„ritt„„ komentojonossa olevan nimi”n, josta suoritus jatkuu.
+
+Nimi” kirjoitetaan omalle rivilleen, joka alkaa kaksoispisteell„.
+.
+
+:TEXT_CMDHELP_HISTORY#1
+N„ytt„„ komentohistorian tai m„„ritt„„ sen koon.
+
+HISTORY [koko]
+
+Ilman parametreja komento n„ytt„„ komentorivihistorian sis„ll”n.
+Jos koko annetaan, komentorivihistorian puskurin kokoa muutetaan.
+.
+
+:TEXT_CMDHELP_IF
+Suorittaa komennon ehdollisesti komentojonoissa.
+
+IF [NOT] ERRORLEVEL luku komento
+IF [NOT] mjono1==mjono2 komento
+IF [NOT] EXIST tnimi komento
+
+  NOT               M„„ritt„„, ett„ komento tulee suorittaa vain,
+                    jos ehto ei ole tosi (normaalisti toisinp„in).
+  ERRORLEVEL luku   M„„ritt„„ ehdon olevan tosi, jos edellisen ohjelman
+                    palauttama lopetuskoodi on suurempi tai yht„ kuin
+                    annettu luku.
+  komento           M„„ritt„„ komennon, joka suoritetaan ehdollisesti.
+  mjono1==mjono2    M„„ritt„„ ehdon olevan tosi, jos annetut kaksi
+                    merkkijonoa ovat samat.
+  EXIST tnimi       M„„ritt„„ ehdon olevan tosi, jos tiedosto on
+                    olemassa annetulla tiedostonimell„.
+.
+
+:TEXT_CMDHELP_LFNFOR
+Ottaa k„ytt””n tai poistaa k„yt”st„ pitk„t tiedostonimet FOR-komennolle
+ja tiedostonimien t„ydennykselle.
+
+LFNFOR [ON | OFF]
+LFNFOR COMPLETE [ON | OFF]
+
+LFNFOR tai LFNFOR COMPLETE ilman parametreja n„ytt„„ nykyisen LFNFOR-tilan.
+.
+
+:TEXT_CMDHELP_LH
+Lataa ohjelman yl„muistiin.
+
+LOADHIGH [asema:][polku]tiedostonimi [parametrit]
+LOADHIGH [/L:alue1[,vkoko1][;alue2[,vkoko2]]...] [/S]]
+         [asema:][polku]tiedostonimi [parametrit]
+
+/L:alue1[,vkoko1][;alue2[,vkoko2]]...
+            M„„ritt„„ muistialueet, joihin ohjelma ladataan.
+            alue1 m„„ritt„„ muistialueen numeron ja vkoko1 m„„ritt„„
+            alueelle mahdollisen v„himm„iskoon. alue2 ja vkoko2
+            m„„ritt„„ toisen alueen numeron ja v„himm„iskoon.
+            Alueiden lukum„„r„„ ei ole rajoitettu.
+
+/S          Pienent„„ yl„muistilohkon (UMB) v„himm„iskokoon,
+            kun ohjelmaa ladataan.
+
+[asema:][polku]tiedostonimi
+            M„„ritt„„ ohjelman nimen ja sijainnin.
+.
+
+:TEXT_CMDHELP_LOADFIX
+Lataa ohjelman muistin ensimm„isen 64 kilotavun yl„puolelle ja ajaa sen.
+
+LOADFIX [asema:][polku]tiedostonimi
+
+Jos ohjelma tulostaa virheen pakatun tiedoston vioittumisesta, kun sen
+ajaa alamuistissa, voit kokeilla ajaa sen LOADFIX-komennolla.
+.
+
+:TEXT_CMDHELP_MD
+Luo hakemiston.
+
+MKDIR [asema:]polku
+MD [asema:]polku
+.
+
+:TEXT_CMDHELP_PATH
+N„ytt„„ tai asettaa ohjelmatiedostojen hakupolun.
+
+PATH [[asema:]polku[;...]]
+PATH ;
+
+PATH ; tyhjent„„ hakupolkuluettelon, jolloin komentokehote hakee
+ohjelmia vain nykyisest„ hakemistosta.
+PATH ilman parametreja n„ytt„„ nykyiset hakupolut.
+.
+
+:TEXT_CMDHELP_PAUSE
+Keskeytt„„ komentojonon suorituksen ja pyyt„„ k„ytt„j„lt„
+n„pp„inpainallusta viestill„, joka on oletuksena
+"Paina mit„ tahansa n„pp„int„ jatkaaksesi...".
+
+PAUSE [viesti]
+.
+
+:TEXT_CMDHELP_PROMPT
+Vaihtaa komentokehotteen esitysmuotoa.
+
+PROMPT [teksti]
+
+  teksti  M„„ritt„„ uuden komentokehotteen esitysmuodon.
+
+Kehotteen muoto voi koostua normaalimerkkien lis„ksi seuraavista
+erityiskoodeista.
+
+  $Q   = (yht„ kuin -merkki)
+  $$   $ (dollarin merkki)
+  $T   Nykyinen aika
+  $D   Nykyinen p„iv„m„„r„
+  $P   Nykyinen asema ja polku
+  $V   FreeDOS-komentokehotteen versio
+  $N   Nykyinen asema
+  $G   > (suurempi kuin -merkki)
+  $L   < (pienempi kuin -merkki)
+  $B   | (putkimerkki tai pystyviiva)
+  $H   Askelpalautin (poistaa edellisen merkin)
+  $E   Escape-koodi (ASCII-koodi 27)
+  $_   Rivinvaihto
+
+PROMPT ilman parametreja palauttaa esitysmuodon oletusasetukseen.
+.
+
+:TEXT_CMDHELP_PUSHD
+Lis„„ nykyisen hakemiston hakemistopolun ylimm„ksi ja mahdollisesti
+vaihtaa toiseen hakemistoon.
+
+PUSHD [[asema:]polku]
+  [asema:]polku on polku, johon halutaan vaihtaa.
+.
+
+:TEXT_CMDHELP_POPD
+Poimii ylimm„n hakemiston hakemistopinosta ja vaihtaa siihen.
+
+POPD [*]
+  '*' tyhjent„„ hakemistopinon.
+.
+
+:TEXT_CMDHELP_DIRS
+N„ytt„„ hakemistopinon sis„ll”n.
+
+DIRS
+.
+
+:TEXT_CMDHELP_RD
+Poistaa tyhj„n hakemiston.
+
+RMDIR [asema:]polku
+RD [asema:]polku
+.
+
+:TEXT_CMDHELP_REM
+Esitt„„ kommenttia komentojonossa tai CONFIG.SYS-tiedostossa.
+
+REM [kommentti]
+.
+
+:TEXT_CMDHELP_REN
+Nime„„ tiedoston/hakemiston tai tiedostot/hakemistot uudelleen.
+
+RENAME [asema:][polku][hnimi1 | tnimi1] [hnimi2 | tnimi2]
+REN [asema:][polku][hnimi1 | tnimi1] [hnimi2 | tnimi2]
+
+T„lle komennolle ei voi m„„ritt„„ kohdeasemaa tai -polkua tiedostolle
+tai hakemistolle. Siirt„miseen tulee k„ytt„„ MOVE-komentoa.
+.
+
+:TEXT_CMDHELP_SET#1
+N„ytt„„, asettaa tai poistaa ymp„rist”muuttujia.
+
+SET [/C] [/P] [/E] [/U] [muuttuja[=[arvo]]]
+
+  muuttuja  M„„ritt„„ ymp„rist”muuttujan nimen.
+  arvo      M„„ritt„„ merkkijonon, joka asetetaan muuttujan arvoksi.
+
+* Jos arvoa ei anneta (VAR=), ymp„rist”muuttuja poistetaan
+
+Kirjoita SET ilman parametreja n„ytt„„ksesi nykyiset ymp„rist”muuttujat.
+Kirjoita SET VAR n„ytt„„ksesi muuttujan VAR arvon.
+
+/C pakottaa pit„m„„n muuttujan kirjainkoot samana; oletuksena muuttujan
+nimi muutetaan isoiksi kirjaimiksi, jos se ei ole jo m„„ritelty
+ymp„rist”ss„, ja muuten pidet„„n samana.
+
+/P kysyy k„ytt„j„lt„ kehotteella arvoa ja asettaa sen muuttujalle.
+
+/E suorittaa arvon mukaisen komennon ja asettaa muuttujan arvoksi
+kyseisen komennon ensimm„isen tulosterivin.
+
+/U muuttaa arvon kirjaimet isoiksi kirjaimiksi.
+.
+
+:TEXT_CMDHELP_SHIFT#1
+Vaihtaa numeroitujen parametrien paikkaa komentojonossa.
+
+SHIFT [DOWN]
+
+DOWN siirt„„ parametri-ikkunaa alkua kohti (%0); muuten
+sit„ siirret„„n loppua kohti.
+.
+
+:TEXT_CMDHELP_TIME#1
+N„ytt„„ tai asettaa j„rjestelm„n ajan.
+
+TIME [/T] [aika]
+
+TIME ilman parametreja tuo n„ytt””n nykyisen kellonajan ja
+kehotteen uudesta ajasta. Paina ENTER pit„„ksesi saman ajan.
+
+/T est„„ komentoa esitt„m„st„ kehotteita.
+.
+
+:TEXT_CMDHELP_TRUENAME
+N„ytt„„ annetun polun koko polkunimen.
+
+TRUENAME [asema:][polku][tiedostonimi]
+.
+
+:TEXT_CMDHELP_TYPE
+N„ytt„„ tekstitiedoston sis„ll”n.
+
+TYPE [asema:][polku]tiedostonimi
+.
+
+:TEXT_CMDHELP_VER
+N„ytt„„ FreeDOS-komentokehotteen version ja muut tiedot.
+
+VER [/R] [/W] [/D] [/C]
+
+ /R         Ytimen versio ja muut tiedot.
+ /W         FreeDOS-komentokehotteen takuutiedot.
+ /D         FreeDOS-komentokehotteen jakelutiedot.
+ /C         FreeDOS-komentokehotteen tekij„t.
+.
+
+:TEXT_CMDHELP_VERIFY
+Kertoo FreeDOS:n tiedostoj„rjestelm„lle, tuleeko tiedostot tarkistaa
+kirjoitusten j„lkeen varmistaakseen, ett„ kirjoitus tehtiin oikein.
+
+VERIFY [ON | OFF]
+
+VERIFY ilman parametria n„ytt„„ nykyisen VERIFY-tilan.
+.
+
+:TEXT_CMDHELP_FDDEBUG
+Jos FreeDOS:iin on k„„nnetty virheenkorjaustoiminnot, t„m„ komento
+kytkee virheenkorjaustulostuksen p„„lle tai pois tai kertoo sen tilan.
+
+FDDEBUG [ON | OFF | tiedosto]
+
+FDDEBUG ilman parametreja n„ytt„„ nykyisen tilan.
+
+Jos tiedosto m„„ritell„„n, virheenkorjaustuloste ohjataan siihen;
+tuloste lis„t„„n tiedoston loppuun, jos se on jo olemassa. erityiset
+tiedostonimet "stdout" ja "stderr" ohjaavat tulosteen joko
+standardituloste- tai standardivirhevirtaan.
+.
+
+:TEXT_CMDHELP_VOL
+N„ytt„„ levyn taltion nimen ja sarjanumeron, jos ne on m„„ritelty.
+
+VOL [asema:]
+.
+
+:TEXT_CMDHELP_QUESTION#1
+N„ytt„„ kehotteessa saatavilla olevat komennot ja toiminnallisuudet.
+
+?
+?komento [argumentti]
+
+Ensimm„inen versio n„ytt„„ kaikki saatavilla olevat komennot ja
+toiminnallisuudet. Toinen versio kysyy kehotteella, suoritetaanko
+kyseist„ komentoa (niin kuin j„ljitystilassa).
+.
+
+:TEXT_CMDHELP_WHICH
+Hakee ja n„ytt„„ komennon toteuttavan ohjelman polun.
+
+WHICH komento...
+.
+
+:TEXT_CMDHELP_MEMORY#1
+N„ytt„„ FreeCOM:n sis„isesti k„ytt„m„n muistin.
+
+MEMORY
+
+.
+
+:TEXT_ERROR_COPY_PLUS_DESTINATION#1
+COPY-komennon kohde ei voi sis„lt„„ plus-merkkej„ ('+').
+.
+
+:TEXT_DELETE_FILE#1%
+Poistetaan tiedostoa "%s".
+.
+
+:TEXT_ERROR_WRITE_FILE_DISC_FULL#0%
+Ei voi kirjoittaa tiedostoa '%s';
+levy ehk„ t„ynn„? (%lu tavua tarvitaan)
+.
+
+# Displayed for BIGcopy(), when copying takes quite a long time.
+# **_NO_END if the input file size is unknown.
+# Both must end in \r rather than \n!!
+:TEXT_COPY_COPIED_NO_END#0%
+kopioitu %luKt/???Kt\r\
+.
+:TEXT_COPY_COPIED#0%
+kopioitu %luKt/%luKt\r\
+.
+
+:TEXT_ERROR_FCOM_IS_DEVICE#0%
+FreeCOM ei voi olla laite: "%s"
+.
+:TEXT_ERROR_FCOM_INVALID#0%
+Tiedosto ei ole kelvollinen FreeCOM tai on v„„r„ versio:
+%s
+.
+
+:TEXT_ERROR_LOADING_STRINGS
+Merkkijonoresurssia ei voitu ladata muistiin. %COMSPEC%-muuttujan
+osoittama sijainti n„ytt„isi olevan virheellinen. M„„rit„ toinen
+sijainti, josta FreeCOM lataa merkkijonot, kuten:
+C:\\COMMAND.COM
+tai paina Enter, jolloin merkkijonojen lataus peruutetaan.
+.
+
+:TEXT_TERMINATING
+Lopetetaan ohjelmaa nyt.
+.
+
+:TEXT_HIDDEN_CRITER#0%
+%u kriittisen virheen pyynt”„ hiljennetty.
+.
+
+# The exit reasons MUST be kept in this order!
+:TEXT_DISP_EXITCODE#0%
+Lopetuskoodi (ERRORLEVEL): %u, syy: %u (%s)
+.
+:TEXT_EXIT_REASON_NEG_1
+DOS-rajapintavirhe\
+.
+:TEXT_EXIT_REASON_0
+p„„ttyi normaalisti\
+.
+:TEXT_EXIT_REASON_1
+p„„ttyi ^Break:iin\
+.
+:TEXT_EXIT_REASON_2
+p„„ttyi virheeseen\
+.
+:TEXT_EXIT_REASON_3
+siirtyi muistiin\
+.
+:TEXT_ERROR_EXE_CORRUPT
+EXE-tiedosto vioittunut\
+.


### PR DESCRIPTION
This commit adds FINNISH.LNG and FINNISH.ERR to STRINGS, which serve as the Finnish translation for FreeCOM

Both files are encoded for code page 850, which is the code page used for Finnish. The only two special characters are ä/ö, the encodings of which coincide across many code pages (including 437).