### PR TITLE
Translations: language keyword got renamed [#48]

### DIFF
--- a/strings/ukr.lng
+++ b/strings/ukr.lng
@@ -258,7 +258,7 @@
 Маэ бути вказано ON чи OFF.
 .
 
-:TEXT_ERROR_BAD_VERABLE
+:TEXT_ERROR_BAD_VARIABLE
 Негоже вказана змўнна.
 .
 


### PR DESCRIPTION
Was causing extra and untranslated string in ukrainian.