### PR TITLE
fix CTTY suitable for serial terminal via AUX (COMn)

### DIFF
--- a/cmd/cls.c
+++ b/cmd/cls.c
@@ -52,11 +52,12 @@
 #include "../include/misc.h"
 
 int cmd_cls (char * param) {
+    int attr = fdattr(1);
     (void)param;
     outc( '\xc' ); /* ^L Form feed */
 
-	/* Output stream is neither a file nor NUL nor CLOCK$ */
-	if(((fdattr(1) ^ 0x80) & (0x80 | 0x08 | 0x04)) == 0) {
+	/* Output stream is standard CON device */
+	if((attr & 0x9f) == 0x93) {
 		unsigned attr = 0x0700;
 		int mode;
 		IREGS r;
@@ -95,6 +96,11 @@ int cmd_cls (char * param) {
 		r.r_dx = ((SCREEN_ROWS - 1) << 8) | (SCREEN_COLS - 1); /* Lower right */
 		intrpt(0x10, &r);
 		goxy(1, 1);			/* home the cursor */
+	}
+	else if((attr & 0x9c) == 0x80) {
+		/* character device neither NUL nor CLOCK$ nor standard CON
+		  (guess AUX or COMn, which is connected commmon serial terminal) */
+		outs( "\x1b[2J" );
 	}
 
 	return 0;

--- a/cmd/ctty.c
+++ b/cmd/ctty.c
@@ -120,6 +120,12 @@ int cmd_ctty(char *param)
 
   if(failed)
     error_ctty_dup(param);
+  else {
+    setCurrentConDev(param);
+    /* workaround: do not use enhanced input if switched device is
+                   not standard 'CON' */
+    set_readcommandType( (attr & 0x9f) == 0x93 );
+  }
 
   return failed;
 }

--- a/include/misc.h
+++ b/include/misc.h
@@ -76,6 +76,8 @@ int vcgetcstr(const char *const legalCh);
 int keypressed(void);
 int cgetchar_timed(int secs);
 int chkCBreak(int mode);
+const char *getCurrenConDev(void);
+int setCurrentConDev(const char * dnam);
 void beep(void);
 void beep_low(void);
 char *comFile(void);
@@ -141,6 +143,7 @@ void partstrlower(char *str);
 void readcommand(char * const str, int maxlen);
 void readcommandDOS(char * const str, int maxlen);
 void readcommandEnhanced(char * const str, const int maxlen);
+int set_readcommandType(int enhanced);
 void convert(unsigned long num, unsigned int billions, char * const des);
 
 void goxy(const unsigned char x, const unsigned char y);

--- a/lib/cbreak.c
+++ b/lib/cbreak.c
@@ -55,17 +55,36 @@
 #include <stdarg.h>
 #include <io.h>     /* _open, _write, _close */
 
+#include <dfn.h>
 #include "../include/batch.h"
 #include "../include/misc.h"
 #include "../include/command.h"
 #include "../strings.h"
+
+static char condev[13] = "CON";
+
+const char * getCurrentConDev(void)
+{
+  return (const char *)condev;
+}
+
+int setCurrentConDev(const char * dnam)
+{
+  const char *nam = dfnfilename(dnam);
+  size_t len = strlen(nam);
+
+  if (len == 0 || len >= sizeof(condev))
+    return -1; /* failed */
+  memcpy(condev, nam, len + 1);
+  return 0; /* ok */
+}
 
 /* This is to prevent all that Turbo C CONIO stuff from being linked in */
 static void mycprintf( char *fmt, ... )
 {
     va_list args;
     char buffer[ 512 ];
-    int consolehandle = dos_open( "CON", O_WRONLY );
+    int consolehandle = dos_open( condev, O_WRONLY );
     /* 
      * Just as cprintf _ensures_ printing directly to the console, so will
      * opening the console and writing to it do the same

--- a/lib/readcmd.c
+++ b/lib/readcmd.c
@@ -9,12 +9,30 @@
 
 #include "../include/command.h"
 
+#ifdef FEATURE_ENHANCED_INPUT
+static int use_enh = 1;
+int set_readcommandType(int enhanced)
+{
+	int rv = use_enh;
+	use_enh = ( enhanced != 0 );
+	return rv;
+}
+#else
+int set_readcommandType(int enhanced)
+{
+	(void)enhanced;
+	return 0;
+}
+#endif
 
 void readcommand(char * const str, int maxlen)
 {
 #ifdef FEATURE_ENHANCED_INPUT
 	/* If redirected from file or so, should use normal one */
-	readcommandEnhanced(str, maxlen);
+	if (use_enh)
+		readcommandEnhanced(str, maxlen);
+	else
+		readcommandDOS(str, maxlen);
 #else
 	readcommandDOS(str, maxlen);
 #endif


### PR DESCRIPTION
* redirect critical error prompt to correct device
* CLS command will work with common serial terminal
* (workaround) use plain readcommandDOS for non-standard CON device