### PR TITLE
Supplement: Match fmem* functions to common prototypes

### DIFF
--- a/suppl/fmemory.h
+++ b/suppl/fmemory.h
@@ -48,14 +48,14 @@
 #define _fmemset farmemset
 
 #else	/* !_PAC_NOCLIB_ */
-void _fmemcpy(void far * const dst, const void far * const src, unsigned length);
-void _fmemset(void far * const dst, int ch, unsigned length);
+void far *_fmemcpy(void far * const dst, const void far * const src, unsigned length);
+void far *_fmemset(void far * const dst, int ch, unsigned length);
 #endif	/* _PAC_NOCLIB_ */
 
 unsigned _fstrlen(const char far * const s);
 char far *_fstrchr(const char far * const s, int ch);
 char far *_fmemchr(const char far * const s, int ch, unsigned length);
-void _fmemmove(void far * const dst, const void far * const src, unsigned length);
+void far *_fmemmove(void far * const dst, const void far * const src, unsigned length);
 int _fmemcmp(const void far * const dst, const void far * const src, unsigned length);
 int _fmemicmp(const void far * const dst, const void far * const src, unsigned length);
 int _fstrcmp(const char far * const dst, const char far * const src);

--- a/suppl/src/fmemcpy.c
+++ b/suppl/src/fmemcpy.c
@@ -58,7 +58,7 @@ void _fmemcpy(unsigned const dseg, unsigned const dofs
 #include <portable.h>
 #include "fmemory.h"
 
-void _fmemcpy(void far * const s1, const void far * const s2, unsigned length)
+void far *_fmemcpy(void far * const s1, const void far * const s2, unsigned length)
 {	byte far*p;
 	const byte far*q;
 
@@ -68,6 +68,7 @@ void _fmemcpy(void far * const s1, const void far * const s2, unsigned length)
 		do *p++ = *q++;
 		while(--length);
 	}
+	return s1;
 }
 
 #endif

--- a/suppl/src/fmemove.c
+++ b/suppl/src/fmemove.c
@@ -83,14 +83,14 @@ void _fmemmove(unsigned dseg, unsigned dofs
 #include <portable.h>
 #include "fmemory.h"
 
-void _fmemmove(void far * const s1, const void far * const s2
+void far *_fmemmove(void far * const s1, const void far * const s2
 	, unsigned length)
 {	byte far *p;
 	byte far *q;
 	byte far *h;
 
 	if(!length)
-		return;
+		return s1;
 
 	p = _fnormalize(s1);
 	q = _fnormalize((void far*)s2);
@@ -117,7 +117,7 @@ void _fmemmove(void far * const s1, const void far * const s2
 				--> copy backwardly
 	*/
 	if(p == q)
-		return;
+		return s1;
 
 	/*
 	 * without the typecasts TC++1 ignores the segment portions completely
@@ -136,6 +136,7 @@ void _fmemmove(void far * const s1, const void far * const s2
 	else {
 		_fmemcpy(s1, s2, length);
 	}
+	return s1;
 }
 #endif
 #endif


### PR DESCRIPTION
Since ia16-elf-gcc's libi86 received support for fmemcpy, fmemmove
and fmemset, its prototypes are in conflict with the replacement
functions defined in the suppl directory. If libi86 implements all
of the support required for FreeCOM in the future, then we may not
need to include suppl, but until then adjust the suppl to match the
common prototypes.

Patch by @tkchia, and discussion at [fixes #79]