### PR TITLE
Supplement: rename intr( ) to intrf( )/_intrf( ), and make its prototype agree with the corresponding functions in Open Watcom and (gcc-ia16 +) libi86

### DIFF
--- a/suppl/compat/dos.h
+++ b/suppl/compat/dos.h
@@ -38,7 +38,7 @@ union REGPACK {
 		unsigned short ax, bx, cx, dx, bp, si, di, ds, es, flags;
 	} x;
 };
-extern void intr(int nr, union REGPACK *r) __attribute__((stdcall));
+extern void _intrf(int nr, union REGPACK *r) __attribute__((regparmcall));
 
 static inline unsigned getpsp(void)
 {

--- a/suppl/p-gcc.h
+++ b/suppl/p-gcc.h
@@ -86,7 +86,7 @@ typedef struct {
     unsigned int    r_es;
     unsigned int    r_flags;
 } IREGS;
-#define intrpt(num,regs) intr((num), (union REGPACK*)(regs))
+#define intrpt(num,regs) _intrf((num), (union REGPACK*)(regs))
 
 static inline unsigned short CS_(void)
 {

--- a/suppl/p-watcom.h
+++ b/suppl/p-watcom.h
@@ -71,7 +71,7 @@ typedef struct {
     unsigned int    r_es;
     unsigned int    r_flags;
 } IREGS;
-#define intrpt(num,regs) intr((num), (union REGPACK*)(regs))
+#define intrpt(num,regs) intrf((num), (union REGPACK*)(regs))
 
 #ifdef __WATCOMC__
 unsigned CS_(void);

--- a/suppl/regproto.h
+++ b/suppl/regproto.h
@@ -82,7 +82,7 @@ extern unsigned _FLAGS;
 #define _DS reg.x.ds
 #define _ES reg.x.es
 #define _CFLAG (reg.x.flags & 1)
-#define geninterrupt(n)  intr(n,&reg)
+#define geninterrupt(n)  intrpt(n,&reg)
 
 #else
 

--- a/suppl/src/intr.asm
+++ b/suppl/src/intr.asm
@@ -34,9 +34,11 @@ segment .text
 
 bits 16
 
-global intr
+global intrf
+global _intrf
 
-intr:
+intrf:
+_intrf:
 
 %elifidni COMPILER, WATCOM 	; and Open Watcom
 %define COMPILE 1
@@ -44,24 +46,22 @@ intr:
 segment _TEXT class=CODE
 
 
-global intr_
+global intrf_
+global _intrf_
 
-intr_:
+intrf_:
+_intrf_:
 %endif
 
 %ifdef COMPILE
 		push	bp			; Standard C entry
 %ifidn __OUTPUT_FORMAT__, elf
-		mov	bp,sp
-		mov	ax, [bp+4]		; interrupt number
-		mov	bx, [bp+6]		; regpack structure
-		push	es
-%else
+		push	es			; gcc-ia16 has es caller-saved
+%endif
 		push	bx
 		push	cx
 		mov	bx, dx
 		push	dx
-%endif
 		push	si
 		push	di
 		push	ds
@@ -87,11 +87,7 @@ intr_1:
 		push	bx
 		mov	bx, sp
 		mov	ds, [ss:bx+6]
-%ifidn __OUTPUT_FORMAT__, elf
-		mov	bx, [ss:bx+20]		; address of REGPACK
-%else
 		mov	bx, [ss:bx+12]		; address of REGPACK
-%endif
 		mov	[bx], ax
 		pop	word [bx+2]
 		mov	[bx+4], cx
@@ -106,15 +102,12 @@ intr_1:
 		pop	ds
 		pop	di
 		pop	si
-%ifidn __OUTPUT_FORMAT__, elf
-		pop	es
-		pop	bp
-		ret	4
-%else
 		pop	dx
 		pop	cx
 		pop	bx
+%ifidn __OUTPUT_FORMAT__, elf
+		pop	es
+%endif
 		pop	bp
 		ret					; retf/retn model specific, see model.inc
-%endif
 %endif


### PR DESCRIPTION
See https://github.com/FDOS/freecom/pull/80#issuecomment-1232741956 .