### PR TITLE
Correct the order of variable assignment in strings\strings.mak

### DIFF
--- a/strings/strings.mak
+++ b/strings/strings.mak
@@ -1,8 +1,8 @@
 CFG_DEPENDENCIES = strings.mak
 
 TOP=..
-!include "$(TOP)/config.mak"
 MMODEL = $(FIXSTRS_MMODEL)
+!include "$(TOP)/config.mak"
 
 all : strings.h strings.err
 


### PR DESCRIPTION
The order of variable assignment seems to be important in Watcom make
fixes #88 