### PR TITLE
Cmp01

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:tkchia/build-ia16
         sudo apt update
-        sudo apt install gcc-ia16-elf nasm upx
+        sudo apt install gcc-ia16-elf libi86-ia16-elf nasm upx
 
     - name: build
       run: ./ci_build.sh

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -5,6 +5,7 @@ RMFILES2 = rm -f
 ECHOTO = echo >>
 ECHOTO0 = echo >>
 CP = cp
+LIBC = -li86
 NASMFLAGS := $(NASMFLAGS) -felf
 SHELL_MMODEL_COMP=cmodel=small
 FIXSTRS_MMODEL=
@@ -14,7 +15,7 @@ CC = ia16-elf-gcc -c
 CL = ia16-elf-gcc -mcmodel=small
 CLO = -o $@
 AR = ia16-elf-ar crsv
-LD = $(CL) $(CFLAGS1) -o command.exe $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) command.ld $(LIBS) -Wl,-Map,command.map \#
+LD = $(CL) $(CFLAGS1) -o command.exe $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) command.ld $(LIBS) $(LIBC) -Wl,-Map,command.map \#
 LIBLIST = >
 ECHOLIB = echo >>
 

--- a/shell/command.mak
+++ b/shell/command.mak
@@ -27,7 +27,7 @@ OBJ4 =	redir.obj\
 	ver.obj
 LIBS = 	..$(DIRSEP)cmd$(DIRSEP)cmds.lib ..$(DIRSEP)lib$(DIRSEP)freecom.lib \
 ..$(DIRSEP)strings$(DIRSEP)strings.lib \
-$(SUPPL_LIB_PATH)$(DIRSEP)suppl_$(SHELL_MMODEL).lib $(LIBC)
+$(SUPPL_LIB_PATH)$(DIRSEP)suppl_$(SHELL_MMODEL).lib
 
 echoto.bat: ../scripts/echoto.bat
 	$(CP) ..$(DIRSEP)scripts$(DIRSEP)echoto.bat .
@@ -41,6 +41,7 @@ command.rsp : echoto.bat
 	$(ECHOTO0) command.rsp command.exe
 	$(ECHOTO0) command.rsp command.map
 	$(ECHOTO0) command.rsp $(LIBS)
+	$(ECHOTO0) command.rsp $(LIBC)
 
 command.exe : $(CFG) $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) $(LIBS) command.rsp
 	$(LD) @command.rsp

--- a/suppl/fmemory.h
+++ b/suppl/fmemory.h
@@ -40,7 +40,7 @@
 #include <string.h>
 
 #else	/* !_TC_LATER_ */
-#if defined(_PAC_NOCLIB_) || defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_PAC_NOCLIB_) || defined(_TC_EARLY_)
 
 #ifdef _PAC_NOCLIB_
 #include <stdlib.h>
@@ -62,7 +62,7 @@ int _fstrcmp(const char far * const dst, const char far * const src);
 int _fstricmp(const char far * const dst, const char far * const src);
 void _fstrcpy(char far * const dst, const char far * const src);
 
-#endif /* defined(_PAC_NOCLIB_) || defined(_TC_EARLY_) || defined(__GNUC__) */
+#endif /* defined(_PAC_NOCLIB_) || defined(_TC_EARLY_) */
 #endif		/* _TC_LATER_ */
 
 #if defined(HI_TECH_C) || defined(_TC_EARLY_)

--- a/suppl/fmemory.h
+++ b/suppl/fmemory.h
@@ -54,13 +54,13 @@ void far *_fmemset(void far * const dst, int ch, unsigned length);
 
 unsigned _fstrlen(const char far * const s);
 char far *_fstrchr(const char far * const s, int ch);
-void far *_fmemchr(const void far * s, int ch, unsigned length);
+char far *_fmemchr(const char far * const s, int ch, unsigned length);
 void far *_fmemmove(void far * const dst, const void far * const src, unsigned length);
 int _fmemcmp(const void far * const dst, const void far * const src, unsigned length);
 int _fmemicmp(const void far * const dst, const void far * const src, unsigned length);
 int _fstrcmp(const char far * const dst, const char far * const src);
 int _fstricmp(const char far * const dst, const char far * const src);
-char far *_fstrcpy(char far * dst, const char far * src);
+void _fstrcpy(char far * const dst, const char far * const src);
 
 #endif /* defined(_PAC_NOCLIB_) || defined(_TC_EARLY_) || defined(__GNUC__) */
 #endif		/* _TC_LATER_ */

--- a/suppl/src/_getdcwd.c
+++ b/suppl/src/_getdcwd.c
@@ -63,9 +63,6 @@ co: Micro-C, Pacific HiTech C
 #ifdef _TC_EARLY_
 #define COMPILE 4
 #endif
-#ifdef __GNUC__
-#define COMPILE 8
-#endif
 
 #ifdef COMPILE
 #include <portable.h>

--- a/suppl/src/cntry.c
+++ b/suppl/src/cntry.c
@@ -106,6 +106,10 @@ co(mpilers):
 
 #include "initsupl.loc"
 
+#ifdef __GNUC__
+#include <libi86/string.h>
+#endif
+
 #ifndef _MICROC_
 #include <dos.h>
 #include <string.h>

--- a/suppl/src/dfnpath.c
+++ b/suppl/src/dfnpath.c
@@ -54,6 +54,9 @@ fi(le): dfnpath.c
 #ifndef _MICROC_
 #include <ctype.h>
 #endif
+#if defined(__GNUC__)
+#include <direct.h>
+#endif
 #include "dfn.loc"
 #include "dynstr.h"
 #include "suppl.h"

--- a/suppl/src/fmemchr.c
+++ b/suppl/src/fmemchr.c
@@ -57,7 +57,7 @@ unsigned _fmemchr(unsigned const seg, unsigned ofs, const unsigned value, unsign
 }
 
 #else
-#if defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_TC_EARLY_)
 #include <portable.h>
 #include "fmemory.h"
 

--- a/suppl/src/fmemchr.c
+++ b/suppl/src/fmemchr.c
@@ -61,12 +61,12 @@ unsigned _fmemchr(unsigned const seg, unsigned ofs, const unsigned value, unsign
 #include <portable.h>
 #include "fmemory.h"
 
-void far *_fmemchr(const void far * s, int ch, unsigned length)
+char far *_fmemchr(const char far* const s, int ch, unsigned length)
 {	const byte far *p;
 
 	for(p = (const byte far*)s; length--; ++p)
 		if(*p == ch)
-			return (void far*)p;
+			return (char far*)p;
 
 	return 0;
 }

--- a/suppl/src/fmemcmp.c
+++ b/suppl/src/fmemcmp.c
@@ -61,7 +61,7 @@ int _fmemcmp(unsigned const dseg, unsigned dofs
 
 #else
 
-#if defined(_PAC_NOCLIB_) || defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_PAC_NOCLIB_) || defined(_TC_EARLY_)
 #include <portable.h>
 #include "fmemory.h"
 

--- a/suppl/src/fmemcpy.c
+++ b/suppl/src/fmemcpy.c
@@ -54,7 +54,7 @@ void _fmemcpy(unsigned const dseg, unsigned const dofs
 
 #else
 
-#if defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_TC_EARLY_)
 #include <portable.h>
 #include "fmemory.h"
 

--- a/suppl/src/fmemory.loc
+++ b/suppl/src/fmemory.loc
@@ -32,7 +32,7 @@
 #define fargPass(name)	 name/**/_segm,  name/**/_ofs
 #endif
 
-#if defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_TC_EARLY_)
 #define COMPILE
 
 #define fargDecl(type,name)	type far * const  name

--- a/suppl/src/fmemove.c
+++ b/suppl/src/fmemove.c
@@ -79,7 +79,7 @@ void _fmemmove(unsigned dseg, unsigned dofs
 }
 
 #else
-#if defined(_PAC_NOCLIB_) || defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_PAC_NOCLIB_) || defined(_TC_EARLY_)
 #include <portable.h>
 #include "fmemory.h"
 

--- a/suppl/src/fstrcpy.c
+++ b/suppl/src/fstrcpy.c
@@ -40,8 +40,7 @@ co(mpilers): Micro-C only
 #include "fmemory.loc"
 
 #ifdef COMPILE
-char far *_fstrcpy(fargDecl(char, dst), fargDecl(const char, src))
-{
-	return (char far *)_fmemcpy(fargPass(dst), fargPass(src), _fstrlen1(src));
+void _fstrcpy(fargDecl(char, dst), fargDecl(const char, src))
+{	_fmemcpy(fargPass(dst), fargPass(src), _fstrlen1(src));
 }
 #endif

--- a/suppl/src/fstrlen.c
+++ b/suppl/src/fstrlen.c
@@ -49,7 +49,7 @@ unsigned _fstrlen(unsigned const seg, unsigned const ofs)
 
 #else
 
-#if defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_TC_EARLY_)
 #include <assert.h>
 #include <portable.h>
 #include "fmemory.h"

--- a/suppl/suppl.h
+++ b/suppl/suppl.h
@@ -340,9 +340,6 @@ void ctrlbrk(int (*fct)(void));
 #ifdef _TC_EARLY_
 #define COMPILE
 #endif
-#ifdef __GNUC__
-#define COMPILE
-#endif
 
 #ifdef COMPILE
 #undef COMPILE

--- a/tools/load_icd.c
+++ b/tools/load_icd.c
@@ -12,7 +12,7 @@
 
 #include "suppl.h"
 #include "portable.h"
-#if defined(_TC_EARLY_) || defined(__GNUC__)
+#if defined(_TC_EARLY_)
 # include "fmemory.h"
 #endif
 

--- a/tools/tools.m2
+++ b/tools/tools.m2
@@ -20,4 +20,4 @@ icmd_3.icd : icmd_inc.inc icmd_3.nas
 	$(NASM) $(NASMFLAGS) -o icmd_3.icd icmd_3.nas
 
 load_icd.exe: load_icd.obj
-	$(CL) $(CLO) load_icd.obj $(SUPPL_LIB_PATH)$(DIRSEP)suppl_$(SHELL_MMODEL).lib
+	$(CL) $(CLO) load_icd.obj $(SUPPL_LIB_PATH)$(DIRSEP)suppl_$(SHELL_MMODEL).lib $(LIBC)


### PR DESCRIPTION
Switch gcc build to use libi86 library functions where possible, which as I reverted incompatible changes to the support library should allow TurboC 2.01 to build again. See https://github.com/FDOS/freecom/commit/5f018a430d2190f78d8f8d3f6b4a5e44c3db8535#commitcomment-150515127