### PR TITLE
Open-Watcom: use safer form of #pragma aux

### DIFF
--- a/cmd/verify.c
+++ b/cmd/verify.c
@@ -24,12 +24,12 @@ void setverify(char a);
 	"mov ah,0x2e" \
 	"mov dl,0" \
 	"int 0x21" \
-	parm [al] modify exact [ah dl]
+	__parm [__al] __modify __exact [__ah __dl]
 char getverify(void);
 #pragma aux getverify = \
 	"mov ah,0x54" \
 	"int 0x21" \
-	value [al] modify exact [ah]
+	__value [__al] __modify __exact [__ah]
 #endif
 
 #ifdef __GNUC__

--- a/include/cswap.h
+++ b/include/cswap.h
@@ -33,7 +33,7 @@ extern int cdecl XMSexec(void);
 
 #ifdef __WATCOMC__
 typedef unsigned long xmsfunc(unsigned request, unsigned dx, void *si);
-#pragma aux xmsfunc = parm [ax] [dx] [si] modify [bx cx]
+#pragma aux xmsfunc = __parm [__ax] [__dx] [__si] __modify [__bx __cx]
 extern xmsfunc far *far XMSdriverAdress;
 #elif defined(__GNUC__)
 extern unsigned far *far XMSdriverAdress;

--- a/lib/exec.c
+++ b/lib/exec.c
@@ -79,7 +79,7 @@ char *parsfnm(const char *cmdline, struct fcb far *fcbptr, int option);
 	"jnz ok" \
 	"xor si, si" \
 	"ok:" \
-	parm [si] [es di] [ax] value [si] modify [ax es]
+	__parm [__si] [__es __di] [__ax] __value [__si] __modify [__ax __es]
 #else
 #pragma aux parsfnm = \
 	"mov ah, 29h" \
@@ -88,7 +88,7 @@ char *parsfnm(const char *cmdline, struct fcb far *fcbptr, int option);
 	"jnz ok" \
 	"xor si, si" \
 	"ok:" \
-	parm [ds si] [es di] [ax] value [ds si] modify [ax es]
+	__parm [__ds __si] [__es __di] [__ax] __value [__ds __si] __modify [__ax __es]
 #endif
 #else /* __GNUC__ */
 static char *parsfnm(const char *cmdline, struct fcb far *fcbptr, int option)

--- a/suppl/p-watcom.h
+++ b/suppl/p-watcom.h
@@ -78,7 +78,7 @@ void intrf(int inter_no, union REGPACK *regs);
 #define intrpt(num,regs) intrf((num), (union REGPACK*)(regs))
 
 unsigned CS_(void);
-#pragma aux CS_ = "mov ax, cs" value[ax];
+#pragma aux CS_ = "mov ax, cs" __value[__ax];
 #define _CS CS_()
 
 /* get/set current working drive */
@@ -87,15 +87,15 @@ extern short getdisk(void);
 	"mov ah, 19h"	\
 	"int 21h"	\
 	"xor ah, ah"	\
-	value [ax]
+	__value [__ax]
 
 extern short setdisk(int newdrive);
 #pragma aux setdisk = \
 	"mov ah, 0eh"	\
 	"int 21h"	\
 	"xor ah, ah"	\
-	parm [dx]	\
-	modify [dx]	\
-	value [ax]
+	__parm [__dx]	\
+	__modify [__dx]	\
+	__value [__ax]
 
 #endif

--- a/suppl/suppl.h
+++ b/suppl/suppl.h
@@ -158,7 +158,7 @@ word resizeBlk(const word segm, const unsigned length);
 /* No differences, only for completeness. */
 
 unsigned BLK_byte2para(const unsigned bytes);
-/* Return the number of paragraphes that will be needed to store ¯bytes®
+/* Return the number of paragraphes that will be needed to store ï¿½bytesï¿½
 	bytes in.
 
 	If bytes == 0, the return value is zero, too.
@@ -178,16 +178,16 @@ int addu(unsigned *u1, unsigned u2);
 #pragma aux addu = \
 	"add word ptr es:[bx], ax"	\
 	"sbb ax, ax"	\
-	parm [es bx] [ax]	\
-	value [ax]	\
-	modify [es bx]
+	__parm [__es __bx] [__ax]   \
+	__value [__ax]  \
+	__modify [__es __bx]
 #else
 #pragma aux addu = \
 	"add word ptr [bx], ax"	\
 	"sbb ax, ax"	\
-	parm [bx] [ax]	\
-	value [ax]	\
-	modify [bx]
+	__parm [__bx] [__ax]    \
+	__value [__ax]  \
+	__modify [__bx]
 #endif
 #endif
 


### PR DESCRIPTION
using ISO standard compiler reserved words form of #pragma aux