### PR TITLE
build: remove # comment like handling linker command

### DIFF
--- a/mkfiles/bc5.mak
+++ b/mkfiles/bc5.mak
@@ -7,7 +7,8 @@ INCLUDEPATH = -I$(CC_BASE_PATH)\INCLUDE
 CC = $(BINPATH)\BCC		# Borland C++
 CL = $(CC)
 AR = $(BINPATH)\Tlib /C
-LD = $(BINPATH)\Tlink /m/s/l /c/d /i
+LD_RSP = command.rsp
+LD = $(BINPATH)\Tlink /m/s/l /c/d /i @$(LD_RSP)
 LIBLIST = ,
 ECHOLIB = echolib
 

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -15,7 +15,7 @@ CC = ia16-elf-gcc -c
 CL = ia16-elf-gcc -mcmodel=small
 CLO = -o $@
 AR = ia16-elf-ar crsv
-LD = $(CL) $(CFLAGS1) -o command.exe $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) command.ld $(LIBS) $(LIBC) -Wl,-Map,command.map \#
+LD = $(CL) $(CFLAGS1) -o command.exe $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) command.ld $(LIBS) $(LIBC) -Wl,-Map,command.map
 LIBLIST = >
 ECHOLIB = echo >>
 

--- a/mkfiles/tc2.mak
+++ b/mkfiles/tc2.mak
@@ -5,7 +5,8 @@ INCLUDEPATH = -I$(CC_BASE_PATH)\INCLUDE
 CC = $(BINPATH)\TCC		# Turbo C/C++
 CL = $(CC)
 AR = $(BINPATH)\Tlib /C
-LD = $(BINPATH)\Tlink /m/s/l /c/d
+LD_RSP = command.rsp
+LD = $(BINPATH)\Tlink /m/s/l /c/d @$(LD_RSP)
 LIBLIST = ,
 ECHOLIB = echolib
 

--- a/mkfiles/turbocpp.mak
+++ b/mkfiles/turbocpp.mak
@@ -7,7 +7,8 @@ INCLUDEPATH = -I$(CC_BASE_PATH)\INCLUDE
 CC = $(BINPATH)\TCC		# Turbo C/C++
 CL = $(CC)
 AR = $(BINPATH)\Tlib /C
-LD = $(BINPATH)\Tlink /m/s/l /c/d
+LD_RSP = command.rsp
+LD = $(BINPATH)\Tlink /m/s/l /c/d @$(LD_RSP)
 LIBLIST = ,
 ECHOLIB = echolib
 

--- a/mkfiles/watcom.mak
+++ b/mkfiles/watcom.mak
@@ -16,14 +16,15 @@ CP = cp
 CC_BASE_PATH = $(WATCOM)
 !ifdef __LINUX__
 BINPATH = $(CC_BASE_PATH)/binl
-LD = $(CL) -l=dos -fe=command.exe $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) $(LIBS) -\"op map,statics,verbose,stack=4k\" $#
+LD = $(CL) -l=dos -fe=command.exe $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) $(LIBS) -\"op map,statics,verbose,stack=4k\"
 !else
 !ifdef Win64
 BINPATH = $(CC_BASE_PATH)\BINNT
 !else
 BINPATH = $(CC_BASE_PATH)\BINW
 !endif
-LD = wlinker /ma/nologo
+LD_RSP = command.rsp
+LD = wlinker /ma/nologo @$(LD_RSP)
 !endif
 LIBPATH = $(CC_BASE_PATH)$(DIRSEP)lib
 INCLUDEPATH = -I$(CC_BASE_PATH)$(DIRSEP)h

--- a/shell/makefile.mak
+++ b/shell/makefile.mak
@@ -40,8 +40,8 @@ command.rsp : echoto.bat
 	$(ECHOTO0) command.rsp $(OBJ4)
 	$(ECHOTO0) command.rsp command.exe
 	$(ECHOTO0) command.rsp command.map
-	$(ECHOTO0) command.rsp $(LIBS)
+	$(ECHOTO0) command.rsp $(LIBS)+
 	$(ECHOTO0) command.rsp $(LIBC)
 
-command.exe : $(CFG) $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) $(LIBS) command.rsp
-	$(LD) @command.rsp
+command.exe : $(CFG) $(OBJ1) $(OBJ2) $(OBJ3) $(OBJ4) $(LIBS) $(LD_RSP)
+	$(LD)


### PR DESCRIPTION
now it is handled transparent way by use of response file only if necessary that it can be changed from response file to command line passing arguments