### PR TITLE
CI: Turbo C 2.01 get and decrypt

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,6 +20,10 @@ jobs:
 
     - name: prerequisites
       run: ./ci_prereq.sh
+      env:
+          TC201_ARCHIVE_PATHNAME: ${{ vars.TC201_ARCHIVE_PATHNAME }}
+          TC201_ARCHIVE_FILENAME: ${{ vars.TC201_ARCHIVE_FILENAME }}
+          TC201_ARCHIVE_PASSPHRASE: ${{ secrets.TC201_ARCHIVE_PASSPHRASE }}
 
     - name: build
       run: ./ci_build.sh

--- a/ci_prereq.sh
+++ b/ci_prereq.sh
@@ -49,6 +49,12 @@ DEVEL=${IBIBLIO_PATH}/devel
 #    get Watcom for DOS
 [ -f watcomc.zip ] || wget --no-verbose ${DEVEL}/watcomc.zip
 
+#    get Turbo C 2.01 (maybe encrypted) tar file
+if [ -n "${TC201_ARCHIVE_FILENAME}" ] && [ ! -f ${TC201_ARCHIVE_FILENAME} ] ; then
+   echo "Downloading Turbo C 2.01"
+   wget --no-verbose ${TC201_ARCHIVE_PATHNAME}/${TC201_ARCHIVE_FILENAME}
+fi
+
 # Unpack the DOS binaries
 mkdir -p ${HOME}/.dosemu/drive_c
 cd ${HOME}/.dosemu/drive_c && (
@@ -74,4 +80,15 @@ cd ${HOME}/.dosemu/drive_c && (
 
   unzip -L -q ${HERE}/watcomc.zip
   echo PATH to watcom binaries is 'c:/devel/watcomc/binw'
+
+  # Turbo C
+  if [ -f ${HERE}/${TC201_ARCHIVE_FILENAME} ] && [ -n "${TC201_ARCHIVE_PASSPHRASE}" ] ; then
+    echo Decrypting and unpacking Turbo C 2.01
+    echo "${TC201_ARCHIVE_PASSPHRASE}" | gpg --decrypt --batch --passphrase-fd 0 ${HERE}/${TC201_ARCHIVE_FILENAME} | tar -jxf -
+  elif [ -f ${HERE}/${TC201_ARCHIVE_FILENAME} ] ; then
+    echo Unpacking Turbo C 2.01
+    tar -jxf ${HERE}/${TC201_ARCHIVE_FILENAME}
+  else
+    echo No Turbo C 2.01 archive available
+  fi
 )

--- a/cmd/makefile.mak
+++ b/cmd/makefile.mak
@@ -8,7 +8,7 @@ all: $(CFG) cmds.lib
 OBJS1 = alias.obj beep.obj break.obj call.obj cdd.obj chcp.obj chdir.obj
 LOBJS1 = $(LIBPLUS)alias.obj $(LIBPLUS)beep.obj $(LIBPLUS)break.obj $(LIBPLUS)call.obj $(LIBPLUS)cdd.obj $(LIBPLUS)chcp.obj $(LIBPLUS)chdir.obj
 OBJS2 = cls.obj copy.obj ctty.obj date.obj del.obj dir.obj dirs.obj
-LOBJS2 = $(LIBPLUS)cls.obj $(LIBPLUS)copy.obj $(LIBPLUS)ctty.obj $(LIBPLUS)date.obj $(LIBPLUS)del.obj dir.obj $(LIBPLUS)dirs.obj
+LOBJS2 = $(LIBPLUS)cls.obj $(LIBPLUS)copy.obj $(LIBPLUS)ctty.obj $(LIBPLUS)date.obj $(LIBPLUS)del.obj $(LIBPLUS)dir.obj $(LIBPLUS)dirs.obj
 OBJS3 = doskey.obj echo.obj exit.obj exit2.obj fddebug.obj for.obj goto.obj
 LOBJS3 = $(LIBPLUS)doskey.obj $(LIBPLUS)echo.obj $(LIBPLUS)exit.obj $(LIBPLUS)exit2.obj $(LIBPLUS)fddebug.obj $(LIBPLUS)for.obj $(LIBPLUS)goto.obj
 OBJS4 = history.obj if.obj lfnfor.obj memory.obj mkdir.obj path.obj pause.obj


### PR DESCRIPTION
@PerditionC I see this GPG encrypted file method as a proof of concept, it works but is far from ideal. I really want all PRs to be checked with Turbo C 2.01, not just those users that have access to the passphrase (you can find that in https://github.com/FDOS/freecom/settings/secrets/actions to copy to your own repo). For this to happen the TC201.tar unencrypted file needs to be hosted somewhere else public.

Note: add the secret TC201_SYMMETRIC_PASSPHRASE to your own freecom github repository secrets to get your PRs built with Turbo C, otherwise they will only be checked fully **after** they have been merged.