### PR TITLE
build: fix build by tlib and response file (Borland tlib)

### DIFF
--- a/cmd/makefile.mak
+++ b/cmd/makefile.mak
@@ -6,29 +6,23 @@ TOP=..
 all: $(CFG) cmds.lib
 
 OBJS1 = alias.obj beep.obj break.obj call.obj cdd.obj chcp.obj chdir.obj
-LOBJS1 = $(LIBPLUS)alias.obj $(LIBPLUS)beep.obj $(LIBPLUS)break.obj $(LIBPLUS)call.obj $(LIBPLUS)cdd.obj $(LIBPLUS)chcp.obj $(LIBPLUS)chdir.obj
 OBJS2 = cls.obj copy.obj ctty.obj date.obj del.obj dir.obj dirs.obj
-LOBJS2 = $(LIBPLUS)cls.obj $(LIBPLUS)copy.obj $(LIBPLUS)ctty.obj $(LIBPLUS)date.obj $(LIBPLUS)del.obj $(LIBPLUS)dir.obj $(LIBPLUS)dirs.obj
 OBJS3 = doskey.obj echo.obj exit.obj exit2.obj fddebug.obj for.obj goto.obj
-LOBJS3 = $(LIBPLUS)doskey.obj $(LIBPLUS)echo.obj $(LIBPLUS)exit.obj $(LIBPLUS)exit2.obj $(LIBPLUS)fddebug.obj $(LIBPLUS)for.obj $(LIBPLUS)goto.obj
 OBJS4 = history.obj if.obj lfnfor.obj memory.obj mkdir.obj path.obj pause.obj
-LOBJS4 = $(LIBPLUS)history.obj $(LIBPLUS)if.obj $(LIBPLUS)lfnfor.obj $(LIBPLUS)memory.obj $(LIBPLUS)mkdir.obj $(LIBPLUS)path.obj $(LIBPLUS)pause.obj
 OBJS5 = popd.obj prompt.obj pushd.obj rem.obj ren.obj rmdir.obj set.obj
-LOBJS5 = $(LIBPLUS)popd.obj $(LIBPLUS)prompt.obj $(LIBPLUS)pushd.obj $(LIBPLUS)rem.obj $(LIBPLUS)ren.obj $(LIBPLUS)rmdir.obj $(LIBPLUS)set.obj
 OBJS6 = shift.obj time.obj truename.obj type.obj verify.obj which.obj
-LOBJS6 = $(LIBPLUS)shift.obj $(LIBPLUS)time.obj $(LIBPLUS)truename.obj $(LIBPLUS)type.obj $(LIBPLUS)verify.obj $(LIBPLUS)which.obj
 
 echolib.bat : ../scripts/echolib.bat
 	$(CP) ..$(DIRSEP)scripts$(DIRSEP)echolib.bat .
 
 cmds.rsp : echolib.bat makefile.mak
 	$(RMFILES) cmds.rsp
-	$(ECHOLIB) cmds.rsp $(LOBJS1) $(LIBCONT)
-	$(ECHOLIB) cmds.rsp $(LOBJS2) $(LIBCONT)
-	$(ECHOLIB) cmds.rsp $(LOBJS3) $(LIBCONT)
-	$(ECHOLIB) cmds.rsp $(LOBJS4) $(LIBCONT)
-	$(ECHOLIB) cmds.rsp $(LOBJS5) $(LIBCONT)
-	$(ECHOLIB) cmds.rsp $(LOBJS6)
+	$(ECHOLIB) cmds.rsp $(OBJS1)
+	$(ECHOLIB) cmds.rsp $(OBJS2)
+	$(ECHOLIB) cmds.rsp $(OBJS3)
+	$(ECHOLIB) cmds.rsp $(OBJS4)
+	$(ECHOLIB) cmds.rsp $(OBJS5)
+	$(ECHOLIB) cmds.rsp $(OBJS6)
 
 cmds.lib : $(CFG) $(OBJS1) $(OBJS2) $(OBJS3) $(OBJS4) $(OBJS5) $(OBJS6) cmds.rsp
 	$(RMFILES) cmds.lib

--- a/lib/makefile.mak
+++ b/lib/makefile.mak
@@ -8,119 +8,83 @@ TOP=..
 all: freecom.lib
 
 OBJS1 = absfile.obj almemblk.obj alprmblk.obj alsysblk.obj app_get.obj app_set.obj beep_l.obj
-LOBJS1 = $(LIBPLUS)absfile.obj $(LIBPLUS)almemblk.obj $(LIBPLUS)alprmblk.obj $(LIBPLUS)alsysblk.obj $(LIBPLUS)app_get.obj $(LIBPLUS)app_set.obj $(LIBPLUS)beep_l.obj
 OBJS2 = beep_n.obj brk_get.obj brk_set.obj cbreak.obj cbs.obj cd_dir.obj cgetch.obj
-LOBJS2 = $(LIBPLUS)beep_n.obj $(LIBPLUS)brk_get.obj $(LIBPLUS)brk_set.obj $(LIBPLUS)cbreak.obj $(LIBPLUS)cbs.obj $(LIBPLUS)cd_dir.obj $(LIBPLUS)cgetch.obj
 OBJS3 = cgettime.obj chgctxt.obj chgdrv.obj chgenv.obj chgenvc.obj chgenvr.obj cmdinput.obj
-LOBJS3 = $(LIBPLUS)cgettime.obj $(LIBPLUS)chgctxt.obj $(LIBPLUS)chgdrv.obj $(LIBPLUS)chgenv.obj $(LIBPLUS)chgenvc.obj $(LIBPLUS)chgenvr.obj $(LIBPLUS)cmdinput.obj
 OBJS4 = comfile.obj compfile.obj critend.obj critrchk.obj ctxt.obj ctxt_adr.obj ctxt_as.obj
-LOBJS4 = $(LIBPLUS)comfile.obj $(LIBPLUS)compfile.obj $(LIBPLUS)critend.obj $(LIBPLUS)critrchk.obj $(LIBPLUS)ctxt.obj $(LIBPLUS)ctxt_adr.obj $(LIBPLUS)ctxt_as.obj
 OBJS5 = ctxt_chg.obj ctxt_clr.obj ctxt_get.obj ctxt_inf.obj ctxt_mk.obj ctxt_mkb.obj ctxt_mkn.obj
-LOBJS5 = $(LIBPLUS)ctxt_chg.obj $(LIBPLUS)ctxt_clr.obj $(LIBPLUS)ctxt_get.obj $(LIBPLUS)ctxt_inf.obj $(LIBPLUS)ctxt_mk.obj $(LIBPLUS)ctxt_mkb.obj $(LIBPLUS)ctxt_mkn.obj
 OBJS6 = ctxt_pop.obj ctxt_psh.obj ctxt_rnu.obj ctxt_set.obj ctxt_ss.obj ctxt_vw.obj curdatel.obj
-LOBJS6 = $(LIBPLUS)ctxt_pop.obj $(LIBPLUS)ctxt_psh.obj $(LIBPLUS)ctxt_rnu.obj $(LIBPLUS)ctxt_set.obj $(LIBPLUS)ctxt_ss.obj $(LIBPLUS)ctxt_vw.obj $(LIBPLUS)curdatel.obj
 OBJS7 = curtime.obj cwd.obj dateget.obj dateset.obj dbg_c.obj dbg_mem.obj dbg_prnt.obj
-LOBJS7 = $(LIBPLUS)curtime.obj $(LIBPLUS)cwd.obj $(LIBPLUS)dateget.obj $(LIBPLUS)dateset.obj $(LIBPLUS)dbg_c.obj $(LIBPLUS)dbg_mem.obj $(LIBPLUS)dbg_prnt.obj
 OBJS8 = dbg_s.obj dbg_sn.obj devopen.obj dfn_err.obj dispcnt.obj dispexit.obj drvnum.obj
-LOBJS8 = $(LIBPLUS)dbg_s.obj $(LIBPLUS)dbg_sn.obj $(LIBPLUS)devopen.obj $(LIBPLUS)dfn_err.obj $(LIBPLUS)dispcnt.obj $(LIBPLUS)dispexit.obj $(LIBPLUS)drvnum.obj
 OBJS9 = efct_001.obj exec.obj exec1.obj farread.obj filecomp.obj fdattr.obj fdevopen.obj
-LOBJS9 = $(LIBPLUS)efct_001.obj $(LIBPLUS)exec.obj $(LIBPLUS)exec1.obj $(LIBPLUS)farread.obj $(LIBPLUS)filecomp.obj $(LIBPLUS)fdattr.obj $(LIBPLUS)fdevopen.obj
 OBJS10 = fdsattr.obj fillcomp.obj find.obj freep.obj frsysblk.obj fstpcpy.obj gallstr.obj
-LOBJS10 = $(LIBPLUS)fdsattr.obj $(LIBPLUS)fillcomp.obj $(LIBPLUS)find.obj $(LIBPLUS)freep.obj $(LIBPLUS)frsysblk.obj $(LIBPLUS)fstpcpy.obj $(LIBPLUS)gallstr.obj
 OBJS11 = get1mcb.obj getenv.obj goxy.obj grabfcom.obj gumblink.obj hdlrctxt.obj hist_get.obj
-LOBJS11 = $(LIBPLUS)get1mcb.obj $(LIBPLUS)getenv.obj $(LIBPLUS)goxy.obj $(LIBPLUS)grabfcom.obj $(LIBPLUS)gumblink.obj $(LIBPLUS)hdlrctxt.obj $(LIBPLUS)hist_get.obj
 OBJS12 = hist_set.obj inputdos.obj is_empty.obj is_fnamc.obj is_fnstr.obj is_pchr.obj isadev.obj
-LOBJS12 = $(LIBPLUS)hist_set.obj $(LIBPLUS)inputdos.obj $(LIBPLUS)is_empty.obj $(LIBPLUS)is_fnamc.obj $(LIBPLUS)is_fnstr.obj $(LIBPLUS)is_pchr.obj $(LIBPLUS)isadev.obj
 OBJS13 = keyprsd.obj kswap_c.obj lastdget.obj lastdset.obj leadopt.obj lfnfuncs.obj lowexec.obj
-LOBJS13 = $(LIBPLUS)keyprsd.obj $(LIBPLUS)kswap_c.obj $(LIBPLUS)lastdget.obj $(LIBPLUS)lastdset.obj $(LIBPLUS)leadopt.obj $(LIBPLUS)lfnfuncs.obj $(LIBPLUS)lowexec.obj
 OBJS14 = ltrimcl.obj ltrimsp.obj lwr1wd.obj match.obj messages.obj mk_rddir.obj mktmpfil.obj
-LOBJS14 = $(LIBPLUS)ltrimcl.obj $(LIBPLUS)ltrimsp.obj $(LIBPLUS)lwr1wd.obj $(LIBPLUS)match.obj $(LIBPLUS)messages.obj $(LIBPLUS)mk_rddir.obj $(LIBPLUS)mktmpfil.obj
 OBJS15 = msg_dflt.obj msg_dps.obj msg_fstr.obj msg_get.obj msg_gpt.obj msg_mkey.obj msg_prmp.obj
-LOBJS15 = $(LIBPLUS)msg_dflt.obj $(LIBPLUS)msg_dps.obj $(LIBPLUS)msg_fstr.obj $(LIBPLUS)msg_get.obj $(LIBPLUS)msg_gpt.obj $(LIBPLUS)msg_mkey.obj $(LIBPLUS)msg_prmp.obj
 OBJS16 = mux_ae.obj myperror.obj nls.obj nls_date.obj nls_time.obj num_fmt.obj onoff.obj
-LOBJS16 = $(LIBPLUS)mux_ae.obj $(LIBPLUS)myperror.obj $(LIBPLUS)nls.obj $(LIBPLUS)nls_date.obj $(LIBPLUS)nls_time.obj $(LIBPLUS)num_fmt.obj $(LIBPLUS)onoff.obj
 OBJS17 = openf.obj optsb.obj optsi.obj optss.obj parsenum.obj pr_date.obj pr_prmpt.obj
-LOBJS17 = $(LIBPLUS)openf.obj $(LIBPLUS)optsb.obj $(LIBPLUS)optsi.obj $(LIBPLUS)optss.obj $(LIBPLUS)parsenum.obj $(LIBPLUS)pr_date.obj $(LIBPLUS)pr_prmpt.obj
 OBJS18 = pr_time.obj prf.obj prprompt.obj readcmd.obj realnum.obj res.obj res_r.obj
-LOBJS18 = $(LIBPLUS)pr_time.obj $(LIBPLUS)prf.obj $(LIBPLUS)prprompt.obj $(LIBPLUS)readcmd.obj $(LIBPLUS)realnum.obj $(LIBPLUS)res.obj $(LIBPLUS)res_r.obj
 OBJS19 = res_vald.obj res_w.obj resfile.obj rmtmpfil.obj rtrimcl.obj rtrimsp.obj salloc.obj
-LOBJS19 = $(LIBPLUS)res_vald.obj $(LIBPLUS)res_w.obj $(LIBPLUS)resfile.obj $(LIBPLUS)rmtmpfil.obj $(LIBPLUS)rtrimcl.obj $(LIBPLUS)rtrimsp.obj $(LIBPLUS)salloc.obj
 OBJS20 = samefile.obj scancmd.obj scanopt.obj session.obj showcmds.obj skqwd.obj spfnam.obj
-LOBJS20 = $(LIBPLUS)samefile.obj $(LIBPLUS)scancmd.obj $(LIBPLUS)scanopt.obj $(LIBPLUS)session.obj $(LIBPLUS)showcmds.obj $(LIBPLUS)skqwd.obj $(LIBPLUS)spfnam.obj
 OBJS21 = split.obj sumblink.obj timeget.obj timeset.obj tmpnam.obj trimcl.obj trimsp.obj
-LOBJS21 = $(LIBPLUS)split.obj $(LIBPLUS)sumblink.obj $(LIBPLUS)timeget.obj $(LIBPLUS)timeset.obj $(LIBPLUS)tmpnam.obj $(LIBPLUS)trimcl.obj $(LIBPLUS)trimsp.obj
 OBJS22 = truepath.obj truncate.obj txtlend.obj unquote.obj vcgetch.obj vcgetstr.obj where.obj
-LOBJS22 = $(LIBPLUS)truepath.obj $(LIBPLUS)truncate.obj $(LIBPLUS)txtlend.obj $(LIBPLUS)unquote.obj $(LIBPLUS)vcgetch.obj $(LIBPLUS)vcgetstr.obj $(LIBPLUS)where.obj
 OBJS23 = delay.obj
-LOBJS23 = $(LIBPLUS)delay.obj
 OBJS24 = err1.obj err2.obj err3.obj err4.obj err5.obj err6.obj err7.obj
-LOBJS24 = $(LIBPLUS)err1.obj $(LIBPLUS)err2.obj $(LIBPLUS)err3.obj $(LIBPLUS)err4.obj $(LIBPLUS)err5.obj $(LIBPLUS)err6.obj $(LIBPLUS)err7.obj
 OBJS25 = err8.obj err9.obj err10.obj err11.obj err12.obj err13.obj err14.obj
-LOBJS25 = $(LIBPLUS)err8.obj $(LIBPLUS)err9.obj $(LIBPLUS)err10.obj $(LIBPLUS)err11.obj $(LIBPLUS)err12.obj $(LIBPLUS)err13.obj $(LIBPLUS)err14.obj
 OBJS26 = err15.obj err16.obj err17.obj err18.obj err19.obj err20.obj err21.obj
-LOBJS26 = $(LIBPLUS)err15.obj $(LIBPLUS)err16.obj $(LIBPLUS)err17.obj $(LIBPLUS)err18.obj $(LIBPLUS)err19.obj $(LIBPLUS)err20.obj $(LIBPLUS)err21.obj
 OBJS27 = err22.obj err23.obj err24.obj err25.obj err26.obj err27.obj err28.obj
-LOBJS27 = $(LIBPLUS)err22.obj $(LIBPLUS)err23.obj $(LIBPLUS)err24.obj $(LIBPLUS)err25.obj $(LIBPLUS)err26.obj $(LIBPLUS)err27.obj $(LIBPLUS)err28.obj
 OBJS28 = err29.obj err30.obj err31.obj err32.obj err33.obj err34.obj err35.obj
-LOBJS28 = $(LIBPLUS)err29.obj $(LIBPLUS)err30.obj $(LIBPLUS)err31.obj $(LIBPLUS)err32.obj $(LIBPLUS)err33.obj $(LIBPLUS)err34.obj $(LIBPLUS)err35.obj
 OBJS29 = err36.obj err37.obj err38.obj err39.obj err40.obj err41.obj err42.obj
-LOBJS29 = $(LIBPLUS)err36.obj $(LIBPLUS)err37.obj $(LIBPLUS)err38.obj $(LIBPLUS)err39.obj $(LIBPLUS)err40.obj $(LIBPLUS)err41.obj $(LIBPLUS)err42.obj
 OBJS30 = err43.obj err44.obj err45.obj err46.obj err47.obj err48.obj err49.obj
-LOBJS30 = $(LIBPLUS)err43.obj $(LIBPLUS)err44.obj $(LIBPLUS)err45.obj $(LIBPLUS)err46.obj $(LIBPLUS)err47.obj $(LIBPLUS)err48.obj $(LIBPLUS)err49.obj
 OBJS31 = err50.obj err51.obj err52.obj err53.obj err54.obj err55.obj err56.obj
-LOBJS31 = $(LIBPLUS)err50.obj $(LIBPLUS)err51.obj $(LIBPLUS)err52.obj $(LIBPLUS)err53.obj $(LIBPLUS)err54.obj $(LIBPLUS)err55.obj $(LIBPLUS)err56.obj
 OBJS32 = err57.obj err58.obj err59.obj err60.obj err61.obj err62.obj err63.obj
-LOBJS32 = $(LIBPLUS)err57.obj $(LIBPLUS)err58.obj $(LIBPLUS)err59.obj $(LIBPLUS)err60.obj $(LIBPLUS)err61.obj $(LIBPLUS)err62.obj $(LIBPLUS)err63.obj
 OBJS33 = err64.obj err65.obj err66.obj err67.obj err68.obj err69.obj err70.obj
-LOBJS33 = $(LIBPLUS)err64.obj $(LIBPLUS)err65.obj $(LIBPLUS)err66.obj $(LIBPLUS)err67.obj $(LIBPLUS)err68.obj $(LIBPLUS)err69.obj $(LIBPLUS)err70.obj
 OBJS34 = err71.obj err72.obj err73.obj err74.obj err75.obj err76.obj err77.obj
-LOBJS34 = $(LIBPLUS)err71.obj $(LIBPLUS)err72.obj $(LIBPLUS)err73.obj $(LIBPLUS)err74.obj $(LIBPLUS)err75.obj $(LIBPLUS)err76.obj $(LIBPLUS)err77.obj
 OBJS35 = err78.obj err79.obj err80.obj err81.obj err82.obj err83.obj err84.obj
-LOBJS35 = $(LIBPLUS)err78.obj $(LIBPLUS)err79.obj $(LIBPLUS)err80.obj $(LIBPLUS)err81.obj $(LIBPLUS)err82.obj $(LIBPLUS)err83.obj $(LIBPLUS)err84.obj
 OBJS36 = err85.obj err86.obj err87.obj
-LOBJS36 = $(LIBPLUS)err85.obj $(LIBPLUS)err86.obj $(LIBPLUS)err87.obj
 
 echolib.bat : ../scripts/echolib.bat
 	$(CP) ..$(DIRSEP)scripts$(DIRSEP)echolib.bat .
 
 freecom.rsp : echolib.bat makefile.mak
 	$(RMFILES) freecom.rsp
-	$(ECHOLIB) freecom.rsp $(LOBJS1) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS2) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS3) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS4) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS5) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS6) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS7) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS8) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS9) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS10) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS11) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS12) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS13) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS14) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS15) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS16) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS17) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS18) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS19) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS20) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS21) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS22) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS23) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS24) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS25) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS26) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS27) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS28) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS29) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS30) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS31) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS32) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS33) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS34) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS35) $(LIBCONT)
-	$(ECHOLIB) freecom.rsp $(LOBJS36)
+	$(ECHOLIB) freecom.rsp $(OBJS1)
+	$(ECHOLIB) freecom.rsp $(OBJS2)
+	$(ECHOLIB) freecom.rsp $(OBJS3)
+	$(ECHOLIB) freecom.rsp $(OBJS4)
+	$(ECHOLIB) freecom.rsp $(OBJS5)
+	$(ECHOLIB) freecom.rsp $(OBJS6)
+	$(ECHOLIB) freecom.rsp $(OBJS7)
+	$(ECHOLIB) freecom.rsp $(OBJS8)
+	$(ECHOLIB) freecom.rsp $(OBJS9)
+	$(ECHOLIB) freecom.rsp $(OBJS10)
+	$(ECHOLIB) freecom.rsp $(OBJS11)
+	$(ECHOLIB) freecom.rsp $(OBJS12)
+	$(ECHOLIB) freecom.rsp $(OBJS13)
+	$(ECHOLIB) freecom.rsp $(OBJS14)
+	$(ECHOLIB) freecom.rsp $(OBJS15)
+	$(ECHOLIB) freecom.rsp $(OBJS16)
+	$(ECHOLIB) freecom.rsp $(OBJS17)
+	$(ECHOLIB) freecom.rsp $(OBJS18)
+	$(ECHOLIB) freecom.rsp $(OBJS19)
+	$(ECHOLIB) freecom.rsp $(OBJS20)
+	$(ECHOLIB) freecom.rsp $(OBJS21)
+	$(ECHOLIB) freecom.rsp $(OBJS22)
+	$(ECHOLIB) freecom.rsp $(OBJS23)
+	$(ECHOLIB) freecom.rsp $(OBJS24)
+	$(ECHOLIB) freecom.rsp $(OBJS25)
+	$(ECHOLIB) freecom.rsp $(OBJS26)
+	$(ECHOLIB) freecom.rsp $(OBJS27)
+	$(ECHOLIB) freecom.rsp $(OBJS28)
+	$(ECHOLIB) freecom.rsp $(OBJS29)
+	$(ECHOLIB) freecom.rsp $(OBJS30)
+	$(ECHOLIB) freecom.rsp $(OBJS31)
+	$(ECHOLIB) freecom.rsp $(OBJS32)
+	$(ECHOLIB) freecom.rsp $(OBJS33)
+	$(ECHOLIB) freecom.rsp $(OBJS34)
+	$(ECHOLIB) freecom.rsp $(OBJS35)
+	$(ECHOLIB) freecom.rsp $(OBJS36)
 
 freecom_deps1 : $(OBJS1) $(OBJS2) $(OBJS3) $(OBJS4) $(OBJS5) $(OBJS6) $(OBJS7) \
 $(OBJS8) $(OBJS9) $(OBJS10) $(OBJS11) $(OBJS12) $(OBJS13) $(OBJS14) $(OBJS15) \

--- a/mkfiles/bc5.mak
+++ b/mkfiles/bc5.mak
@@ -9,8 +9,6 @@ CL = $(CC)
 AR = $(BINPATH)\Tlib /C
 LD_RSP = command.rsp
 LD = $(BINPATH)\Tlink /m/s/l /c/d /i @$(LD_RSP)
-LIBPLUS = +
-LIBCONT = & #
 LIBLIST = ,
 ECHOLIB = echolib
 

--- a/mkfiles/tc2.mak
+++ b/mkfiles/tc2.mak
@@ -7,8 +7,6 @@ CL = $(CC)
 AR = $(BINPATH)\Tlib /C
 LD_RSP = command.rsp
 LD = $(BINPATH)\Tlink /m/s/l /c/d @$(LD_RSP)
-LIBPLUS = +
-LIBCONT = & #
 LIBLIST = ,
 ECHOLIB = echolib
 

--- a/mkfiles/turbocpp.mak
+++ b/mkfiles/turbocpp.mak
@@ -9,8 +9,6 @@ CL = $(CC)
 AR = $(BINPATH)\Tlib /C
 LD_RSP = command.rsp
 LD = $(BINPATH)\Tlink /m/s/l /c/d @$(LD_RSP)
-LIBPLUS = +
-LIBCONT = & #
 LIBLIST = ,
 ECHOLIB = echolib
 

--- a/scripts/echolib.bat
+++ b/scripts/echolib.bat
@@ -1,6 +1,40 @@
 @echo off
 if "%2%3%4%5%6%7%8%9" == "" goto nothing
-echo %2 %3 %4 %5 %6 %7 %8 %9 >>%1
+if '^(' == '(' goto :cmd_shell
+echo +%2 & >>%1
+if "%3%" == "" goto nothing
+echo +%3 & >>%1
+if "%4%" == "" goto nothing
+echo +%4 & >>%1
+if "%5" == "" goto nothing
+echo +%5 & >>%1
+if "%6" == "" goto nothing
+echo +%6 & >>%1
+if "%7" == "" goto nothing
+echo +%7 & >>%1
+if "%8" == "" goto nothing
+echo +%8 & >>%1
+if "%9" == "" goto nothing
+echo +%9 & >>%1
+goto :args_check
+:cmd_shell
+echo +%2 ^& >>%1
+if "%3%" == "" goto nothing
+echo +%3 ^& >>%1
+if "%4%" == "" goto nothing
+echo +%4 ^& >>%1
+if "%5" == "" goto nothing
+echo +%5 ^& >>%1
+if "%6" == "" goto nothing
+echo +%6 ^& >>%1
+if "%7" == "" goto nothing
+echo +%7 ^& >>%1
+if "%8" == "" goto nothing
+echo +%8 ^& >>%1
+if "%9" == "" goto nothing
+echo +%9 ^& >>%1
+:args_check
 shift
-if not "%9" == "" echo echolib.bat arguments overflow
+if "%9" == "" goto nothing
+echo echolib.bat arguments overflow
 :nothing

--- a/suppl/src/makefile.mak
+++ b/suppl/src/makefile.mak
@@ -9,48 +9,27 @@ CC = $(CC) -I..
 all : ../$(SUPPL).lib
 
 OBJS1 = addu.obj byte2par.obj cntry.obj dfndeli2.obj dfndelim.obj dfnexpan.obj dfnfnam.obj
-LOBJS1 = $(LIBPLUS)addu.obj $(LIBPLUS)byte2par.obj $(LIBPLUS)cntry.obj $(LIBPLUS)dfndeli2.obj $(LIBPLUS)dfndelim.obj $(LIBPLUS)dfnexpan.obj $(LIBPLUS)dfnfnam.obj
 OBJS2 = dfnfullp.obj dfnmerge.obj dfnpath.obj dfnsplit.obj dfnsquee.obj dfnstat.obj
-LOBJS2 = $(LIBPLUS)dfnfullp.obj $(LIBPLUS)dfnmerge.obj $(LIBPLUS)dfnpath.obj $(LIBPLUS)dfnsplit.obj $(LIBPLUS)dfnsquee.obj $(LIBPLUS)dfnstat.obj
 OBJS3 = dfntruen.obj dmemcmpf.obj dosalloc.obj dosfree.obj dossize.obj dstrchar.obj
-LOBJS3 = $(LIBPLUS)dfntruen.obj $(LIBPLUS)dmemcmpf.obj $(LIBPLUS)dosalloc.obj $(LIBPLUS)dosfree.obj $(LIBPLUS)dossize.obj $(LIBPLUS)dstrchar.obj
 OBJS4 = dstrfupr.obj dstrleft.obj dstrrepl.obj dstrtrim.obj dstrupr.obj enoallc.obj
-LOBJS4 = $(LIBPLUS)dstrfupr.obj $(LIBPLUS)dstrleft.obj $(LIBPLUS)dstrrepl.obj $(LIBPLUS)dstrtrim.obj $(LIBPLUS)dstrupr.obj $(LIBPLUS)enoallc.obj
 OBJS5 = enoreal.obj enosdup.obj enosetos.obj env_chg.obj env_del.obj env_dvar.obj env_find.obj
-LOBJS5 = $(LIBPLUS)enoreal.obj $(LIBPLUS)enosdup.obj $(LIBPLUS)enosetos.obj $(LIBPLUS)env_chg.obj $(LIBPLUS)env_del.obj $(LIBPLUS)env_dvar.obj $(LIBPLUS)env_find.obj
 OBJS6 = env_fora.obj env_free.obj env_insv.obj env_len.obj env_mtch.obj env_new.obj
-LOBJS6 = $(LIBPLUS)env_fora.obj $(LIBPLUS)env_free.obj $(LIBPLUS)env_insv.obj $(LIBPLUS)env_len.obj $(LIBPLUS)env_mtch.obj $(LIBPLUS)env_new.obj
 OBJS7 = env_nost.obj env_ovrw.obj env_repl.obj env_rlsg.obj env_scnt.obj env_size.obj
-LOBJS7 = $(LIBPLUS)env_nost.obj $(LIBPLUS)env_ovrw.obj $(LIBPLUS)env_repl.obj $(LIBPLUS)env_rlsg.obj $(LIBPLUS)env_scnt.obj $(LIBPLUS)env_size.obj
 OBJS8 = env_strg.obj env_sub.obj env_var1.obj env_var2.obj ffmaxbuf.obj fgetpos.obj
-LOBJS8 = $(LIBPLUS)env_strg.obj $(LIBPLUS)env_sub.obj $(LIBPLUS)env_var1.obj $(LIBPLUS)env_var2.obj $(LIBPLUS)ffmaxbuf.obj $(LIBPLUS)fgetpos.obj
 OBJS9 = fmemchr.obj fmemcmp.obj fmemcpy.obj fmemove.obj fnorm.obj fputmc.obj fstrcpy.obj
-LOBJS9 = $(LIBPLUS)fmemchr.obj $(LIBPLUS)fmemcmp.obj $(LIBPLUS)fmemcpy.obj $(LIBPLUS)fmemove.obj $(LIBPLUS)fnorm.obj $(LIBPLUS)fputmc.obj $(LIBPLUS)fstrcpy.obj
 OBJS10 = fstrdup.obj fstrlen.obj _getdcwd.obj mcb_1st.obj mcb_is.obj mcb_leng.obj  mcb_nxt.obj
-LOBJS10 = $(LIBPLUS)fstrdup.obj $(LIBPLUS)fstrlen.obj $(LIBPLUS)_getdcwd.obj $(LIBPLUS)mcb_1st.obj $(LIBPLUS)mcb_is.obj $(LIBPLUS)mcb_leng.obj $(LIBPLUS)mcb_nxt.obj
 OBJS11 = mcb_walk.obj stpcat.obj stpcpy.obj toupperx.obj filefind.obj invokedo.obj intr.obj
-LOBJS11 = $(LIBPLUS)mcb_walk.obj $(LIBPLUS)stpcat.obj $(LIBPLUS)stpcpy.obj $(LIBPLUS)toupperx.obj $(LIBPLUS)filefind.obj $(LIBPLUS)invokedo.obj $(LIBPLUS)intr.obj
 
 DOBJS1 = app_ievx.obj app_ini_.obj app_name.obj app_namx.obj app_vars.obj dbgf_chg.obj
-LDOBJS1 = $(LIBPLUS)app_ievx.obj $(LIBPLUS)app_ini_.obj $(LIBPLUS)app_name.obj $(LIBPLUS)app_namx.obj $(LIBPLUS)app_vars.obj $(LIBPLUS)dbgf_chg.obj
 DOBJS2 = dbgf_cl.obj dbgf_cle.obj dbgf_clg.obj dbgf_dl.obj dbgf_dpl.obj dbgf_et.obj
-LDOBJS2 = $(LIBPLUS)dbgf_cl.obj $(LIBPLUS)dbgf_cle.obj $(LIBPLUS)dbgf_clg.obj $(LIBPLUS)dbgf_dl.obj $(LIBPLUS)dbgf_dpl.obj $(LIBPLUS)dbgf_et.obj
 DOBJS3 = dbgf_ext.obj dbgf_fl.obj dbgf_flg.obj dbgf_ien.obj dbgf_lgh.obj dbgf_lgi.obj
-LDOBJS3 = $(LIBPLUS)dbgf_ext.obj $(LIBPLUS)dbgf_fl.obj $(LIBPLUS)dbgf_flg.obj $(LIBPLUS)dbgf_ien.obj $(LIBPLUS)dbgf_lgh.obj $(LIBPLUS)dbgf_lgi.obj
 DOBJS4 = dbgf_lgt.obj dbgf_lk.obj dbgf_log.obj dbgf_lv.obj dbgf_mfi.obj dbgf_mi.obj
-LDOBJS4 = $(LIBPLUS)dbgf_lgt.obj $(LIBPLUS)dbgf_lk.obj $(LIBPLUS)dbgf_log.obj $(LIBPLUS)dbgf_lv.obj $(LIBPLUS)dbgf_mfi.obj $(LIBPLUS)dbgf_mi.obj
 DOBJS5 = dbgf_mki.obj dbgf_ml.obj dbgf_pop.obj dbgf_prt.obj dbgf_psh.obj dbgf_var.obj
-LDOBJS5 = $(LIBPLUS)dbgf_mki.obj $(LIBPLUS)dbgf_ml.obj $(LIBPLUS)dbgf_pop.obj $(LIBPLUS)dbgf_prt.obj $(LIBPLUS)dbgf_psh.obj $(LIBPLUS)dbgf_var.obj
 DOBJS6 = dbgm_chk.obj dbgv_s0.obj dbgv_s2.obj dbgv_s3.obj dbgv_s4.obj dbgv_s5.obj
-LDOBJS6 = $(LIBPLUS)dbgm_chk.obj $(LIBPLUS)dbgv_s0.obj $(LIBPLUS)dbgv_s2.obj $(LIBPLUS)dbgv_s3.obj $(LIBPLUS)dbgv_s4.obj $(LIBPLUS)dbgv_s5.obj
 DOBJS7 = dbgv_s6.obj dbgv_s7.obj dbgv_s8.obj dbgv_s10.obj dbgv_s13.obj dbgv_s14.obj
-LDOBJS7 = $(LIBPLUS)dbgv_s6.obj $(LIBPLUS)dbgv_s7.obj $(LIBPLUS)dbgv_s8.obj $(LIBPLUS)dbgv_s10.obj $(LIBPLUS)dbgv_s13.obj $(LIBPLUS)dbgv_s14.obj
 DOBJS8 = dbgv_s15.obj dbgv_s17.obj dbgv_s19.obj dbgv_s20.obj dbgv_s22.obj dbgv_s25.obj
-LDOBJS8 = $(LIBPLUS)dbgv_s15.obj $(LIBPLUS)dbgv_s17.obj $(LIBPLUS)dbgv_s19.obj $(LIBPLUS)dbgv_s20.obj $(LIBPLUS)dbgv_s22.obj $(LIBPLUS)dbgv_s25.obj
 DOBJS9 = eeopen.obj eestrcon.obj env_sdup.obj erfc_00f.obj erfc_015.obj gm_res.obj 
-LDOBJS9 = $(LIBPLUS)eeopen.obj $(LIBPLUS)eestrcon.obj $(LIBPLUS)env_sdup.obj $(LIBPLUS)erfc_00f.obj $(LIBPLUS)erfc_015.obj $(LIBPLUS)gm_res.obj 
 DOBJS10 = gm_dup.obj gm_chgm.obj gm_gtmem.obj nlstime.obj strnum.obj s_skipws.obj s_skipwd.obj
-LDOBJS10 = $(LIBPLUS)gm_dup.obj $(LIBPLUS)gm_chgm.obj $(LIBPLUS)gm_gtmem.obj $(LIBPLUS)nlstime.obj $(LIBPLUS)strnum.obj $(LIBPLUS)s_skipws.obj $(LIBPLUS)s_skipwd.obj
 
 echolib.bat: ../../scripts/echolib.bat
 	$(CP) ..$(DIRSEP)..$(DIRSEP)scripts$(DIRSEP)echolib.bat .
@@ -58,27 +37,27 @@ echolib.bat: ../../scripts/echolib.bat
 # Prepare Linker Response File
 objlist.txt: echolib.bat makefile.mak
 	$(RMFILES2) objlist.txt
-	$(ECHOLIB) objlist.txt $(LOBJS1) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS2) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS3) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS4) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS5) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS6) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS7) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS8) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS9) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS10) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LOBJS11) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS1) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS2) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS3) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS4) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS5) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS6) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS7) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS8) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS9) $(LIBCONT)
-	$(ECHOLIB) objlist.txt $(LDOBJS10)
+	$(ECHOLIB) objlist.txt $(OBJS1)
+	$(ECHOLIB) objlist.txt $(OBJS2)
+	$(ECHOLIB) objlist.txt $(OBJS3)
+	$(ECHOLIB) objlist.txt $(OBJS4)
+	$(ECHOLIB) objlist.txt $(OBJS5)
+	$(ECHOLIB) objlist.txt $(OBJS6)
+	$(ECHOLIB) objlist.txt $(OBJS7)
+	$(ECHOLIB) objlist.txt $(OBJS8)
+	$(ECHOLIB) objlist.txt $(OBJS9)
+	$(ECHOLIB) objlist.txt $(OBJS10)
+	$(ECHOLIB) objlist.txt $(OBJS11)
+	$(ECHOLIB) objlist.txt $(DOBJS1)
+	$(ECHOLIB) objlist.txt $(DOBJS2)
+	$(ECHOLIB) objlist.txt $(DOBJS3)
+	$(ECHOLIB) objlist.txt $(DOBJS4)
+	$(ECHOLIB) objlist.txt $(DOBJS5)
+	$(ECHOLIB) objlist.txt $(DOBJS6)
+	$(ECHOLIB) objlist.txt $(DOBJS7)
+	$(ECHOLIB) objlist.txt $(DOBJS8)
+	$(ECHOLIB) objlist.txt $(DOBJS9)
+	$(ECHOLIB) objlist.txt $(DOBJS10)
 
 # Create the library
 ../$(SUPPL).lib: $(OBJS1) $(OBJS2) $(OBJS3) $(OBJS4) $(OBJS5) $(OBJS6) \


### PR DESCRIPTION
fix special handling of (&) character for Windows cmd.exe shell fix (+)add character handling

remove useless second list for librarian, now handled in echolib.bat without any environment variable