### PR TITLE
build: add ptchsize as native build for cross-compilation

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -179,8 +179,8 @@ cd ..
 echo.
 echo Patching heap size to 6KB
 echo.
-tools\ptchsize.exe command.com +6KB
-tools\ptchsize.exe %CMD_NAME% +6KB
+utils\ptchsize.exe command.com +6KB
+utils\ptchsize.exe %CMD_NAME% +6KB
 
 if %WITH_UPX%x == x goto alldone
 if exist command.upx del command.upx >nul

--- a/build.sh
+++ b/build.sh
@@ -198,7 +198,7 @@ cd ..
 echo
 echo Patching heap size to 6KB
 echo
-tools/ptchsize.exe command.com +6KB
+utils/ptchsize.exe command.com +6KB
 
 if [ $WITH_UPX = "yes" ]; then
   rm -f command.upx

--- a/mkdist.bat
+++ b/mkdist.bat
@@ -69,11 +69,11 @@ set XMS_SWAP=Yes
 dmake || quit
 %_DBG setdos /y1 %+ %_DBG echo on
 if not exist com.com goto ende
-iff not exist tools\ptchsize.exe then
+iff not exist utils\ptchsize.exe then
 	echo no PTCHSIZE
 	goto ende
 endiff
-tools\ptchsize.exe com.com +7KB
+utils\ptchsize.exe com.com +7KB
 if errorlevel 1 goto ende
 move com.com packages\xmsswap.std\command.com
 copy /b shell\com.exe +infores + criter\criter + criter\criter1 packages\localize.std\xmsswap.cln
@@ -97,11 +97,11 @@ ren /q config.h.backup config.h || cancel 21
 
 if not x%err == x cancel %err
 if not exist com.com goto ende
-iff not exist tools\ptchsize.exe then
+iff not exist utils\ptchsize.exe then
 	echo no PTCHSIZE
 	goto ende
 endiff
-tools\ptchsize.exe com.com +6KB
+utils\ptchsize.exe com.com +6KB
 if errorlevel 1 goto ende
 move com.com packages\plainedt.std\command.com
 if exist com.com goto ende
@@ -119,11 +119,11 @@ if not exist com.com goto ende
 copy /b shell\com.exe +infores + criter\criter + criter\criter1 command.cln
 ren com.com command.com
 if exist com.com goto ende
-iff not exist tools\ptchsize.exe then
+iff not exist utils\ptchsize.exe then
 	echo no PTCHSIZE
 	goto ende
 endiff
-tools\ptchsize.exe command.com +6KB
+utils\ptchsize.exe command.com +6KB
 if errorlevel 1 goto ende
 
 for %file in (tools\kssf.com tools\vspawn.com tools\ptchldrv.exe tools\ptchsize.exe) (if exist %file copy %file packages\plainedt.std\ %+ if exist %file move %file packages\binary.std\ %+ if exist %file goto ende)

--- a/utils/makefile.mak
+++ b/utils/makefile.mak
@@ -3,6 +3,7 @@ CFG_DEPENDENCIES = makefile.mak
 TOP=..
 !include "$(TOP)/config.mak"
 
-all: $(CFG) mktools.exe mkctxt.exe chunk.exe mkinfres.exe
+all: $(CFG) mktools.exe mkctxt.exe chunk.exe mkinfres.exe ptchsize.exe
 
-mktools.exe : ../config.h
+mktools.exe : mktools.c ../config.h
+ptchsize.exe : ptchsize.c ../tools/ptchsize.c

--- a/utils/ptchsize.c
+++ b/utils/ptchsize.c
@@ -1,0 +1,4 @@
+/*
+        Redirection file to enable native host build of ptchsize utility
+*/
+#include "../tools/ptchsize.c"


### PR DESCRIPTION
ptchsize is build tool (used by FREECOM build) and also DOS target tool
now
- in tools (DOS tools included in distribution) is DOS version 
- in utils (host native tools used by FREECOM build) is host OS version