### PR TITLE
build: fix cross-compile setup for gcc and Open Watcom

### DIFF
--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -9,11 +9,11 @@ RMFILES = rm -f
 CP = cp
 LIBC = -li86
 NASMFLAGS := $(NASMFLAGS) -felf
-SHELL_MMODEL_COMP=cmodel=small
-COMPACT_MMODEL=
-INCLUDEPATH=-I. -I../compat -I../suppl/compat
+SHELL_MMODEL_COMP = cmodel=small
+INCLUDEPATH = -I. -I../compat -I../suppl/compat
+COMPACT_MMODEL = -mcmodel=compact
 
-CC = ia16-elf-gcc -c
+CC = ia16-elf-gcc
 CL = ia16-elf-gcc -mcmodel=small
 CLO = -o $@
 AR = ia16-elf-ar crsv
@@ -25,7 +25,23 @@ CFLAGS1 = -Os -Wall -Werror -Wno-pointer-to-int-cast -Wno-incompatible-pointer-t
 #		*Implicit Rules*
 .SUFFIXES:
 .SUFFIXES: .c .asm .com .exe .obj
+ifeq ($(UTILS_BUILD),1)
 .c.exe:
 	gcc -x c -Og -g -Wall -DGCC -D__GETOPT_H -I../suppl $< -o $@
+else ifeq ($(COMPACT_MODEL),1)
+.c.obj .c.exe:
+	@echo ------------------------------------------------------
+	@echo "$@ (DOS version) is not build because"
+	@echo ia16-elf-gcc does not support the compact memory model
+	@echo ------------------------------------------------------
+
+.obj.exe:
+
+else
 .c.obj:
-	$(CC) $< @$(CFG) -o $@
+	$(CC) -c $< @$(CFG) -o $@
+
+.c.exe .obj.exe:
+	$(CL) $< @$(CFG) $(LIBS) $(LIBC) -o $@
+
+endif

--- a/utilsc/makefile.mak
+++ b/utilsc/makefile.mak
@@ -9,6 +9,6 @@ TOP=..
 
 all : $(CFG) fixstrs.exe critstrs.exe
 
-fixstrs.exe: $(CFG) fixstrs.c ../strings/fixstrs.c
+fixstrs.exe: fixstrs.c ../strings/fixstrs.c
 
-critstrs.exe: $(CFG) critstrs.c
+critstrs.exe: critstrs.c


### PR DESCRIPTION
gcc doesn't support compact memory model
configuration handle this special case by generating appropriate message, now it happens only for fixstrs.exe (in strings)

Open Watcom can be run from Windows or Linux or DOS
only necessary is define WATCOM env. variable and add host OW binaries on the PATH, all other is handled by make files