### PR TITLE
ecm loadhigh

### DIFF
--- a/shell/loadhigh.c
+++ b/shell/loadhigh.c
@@ -462,8 +462,13 @@ static int loadhigh_prepare(void)
         /* Found a free memory block: allocate it */
         word bl = DosAlloc(mcb->mcb_size);
 
-        if (bl != FP_SEG(mcb) + 1)  /* Did we get the block we wanted? */
+        if (bl != FP_SEG(mcb) + 1) {  /* Did we get the block we wanted? */
+          DOSfree(bl);
+          for (i = 0; i < availBlocks; i++)
+            DOSfree(availBlock[i]);
+          free(availBlock);
           return err_mcb_chain;
+        }
 
         if (region->access)		/* /L option allows access to this region */
         {

--- a/shell/loadhigh.c
+++ b/shell/loadhigh.c
@@ -347,8 +347,10 @@ static int findUMBRegions(void)
         if (region->start)
         {
           region->end = FP_SEG(mcb) - 1;
-          region++;
-          region->start = 0;
+          if (! (mcb->mcb_type == 'Z' && 0 == mcb->mcb_size)) {
+            region++;
+            region->start = 0;
+          }
         }
       }
       else
@@ -625,7 +627,7 @@ static int parseArgs(char *cmdline, char **fnam, char **rest)
 
     /* Disable access to all UMB regions not listed here */
     for (i = 1; i < umbRegions; i++)
-    umbRegion[i].access = 0;
+      umbRegion[i].access = 0;
 
     r = 0;
 

--- a/shell/loadhigh.c
+++ b/shell/loadhigh.c
@@ -339,7 +339,9 @@ static int findUMBRegions(void)
     {
       sig = mcb->mcb_type;
 
-      if (mcb->mcb_ownerPSP == 8 && !_fmemcmp(mcb->mcb_name, "SC", 2))
+      if (mcb->mcb_ownerPSP == 8
+        && (!_fmemcmp(mcb->mcb_name, "SC", 2)
+          || !_fmemcmp(mcb->mcb_name, "S\x00\x30", 3))) /* lDOS S MCB type 30h */
       {
         /* this is a 'hole' in memory */
         if (region->start)

--- a/shell/loadhigh.c
+++ b/shell/loadhigh.c
@@ -454,7 +454,7 @@ static int loadhigh_prepare(void)
     int found_one = 0;
 
     for (mcbAssign(mcb, region->start)
-     ; FP_SEG(mcb) < region->end && mcb->mcb_type == 'M' && mcb->mcb_size > 0
+     ; FP_SEG(mcb) < region->end && mcb->mcb_type == 'M'
      ; mcbNext(mcb))
     {
       if (!mcb->mcb_ownerPSP)


### PR DESCRIPTION
Reference: https://github.com/FDOS/freecom/issues/166

There is one remaining oddity: If an out of bounds region is selected with eg `/L:4` then the 3rd region is partially freed whereas I would expect it to be fully reserved like the 1st and 2nd regions. Log of a test session:

```
&; Welcome to lDebug!
Press any key to enter debugger terminal!
Timer stopped
V0=000000A5 V1=00000000 V2=00000000 V3=00000000  DCO=00000000 DCS=00000000
V4=00000000 V5=00000000 V6=00000000 V7=00000000  DAO=0000F007 DAS=0000F007
V8=00000000 V9=00000000 VA=00000000 VB=00000000  DIF=0180F008 DPI=0000:0000
VC=00000000 VD=00000000 VE=00000000 VF=00000000  DPR=7601     DPP=0000
Current mode: Virtual 86 Mode
-ldos
-q
Starting small lDOS (2025 February) based on MS-DOS v4.01
dosemu XMS 3.0 & UMB support enabled
init: Successfully relocated DOSCODE into the HMA.
init: UMB of size 2000h ( 128 KiB) at C000h allocated.
init: UMB of size 0A00h (  40 KiB) at F000h allocated.
init: UMB of size 0800h (  32 KiB) at B000h allocated.
EMUFS host file and print access available
dosemu EMS driver rev 0.9 installed.
dosemu CDROM driver installed (V0.2)
emufs: redirector enabled

FreeCom version 0.87 - GNUC - XMS_Swap [Feb 18 2025 19:57:17]
SEEKEXT 1.21: high loaded using 416 byte, on multiplex 00h.
emufs: redirector enabled
Welcome to dosemu2!
    Build 2.0pre9-dev-20240420-1892-g6a2f4f527
C:\>lh ldebug /cdm;q
&dm
PSP: 2950
025C 4D 0008 001A     416 B S type 09 S_UPB
0277 4D 0008 0009     144 B S type 08 S_DPB
0281 4D 0008 0000       0 B SD
0282 4D 0283 26CC   155 KiB LDEBUG
294F 4D 2950 76AF   474 KiB DEBUGGEE
9FFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
B000 4D 0008 0047    1136 B SD
B048 4D 0008 00CC   3.1 KiB S type 04 S_IRQSCODE
B115 4D C001 0100   4.0 KiB COMMAND
B216 4D B217 0019     400 B SEEKEXT
B230 4D 0000 05CE  23.2 KiB
B7FF 4D 0008 0800  32.0 KiB S type 30 S_EXCLDUMA
C000 4D C001 00A9   2.6 KiB COMMAND
C0AA 4D 0000 1F54   125 KiB
DFFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
F000 4D 0000 09FE  39.9 KiB
F9FF 5A 0008 0000       0 B S type 30 S_EXCLDUMA
&q
C:\>lh /l:1 ldebug /cdm;q
&dm
PSP: 2950
025C 4D 0008 001A     416 B S type 09 S_UPB
0277 4D 0008 0009     144 B S type 08 S_DPB
0281 4D 0008 0000       0 B SD
0282 4D 0283 26CC   155 KiB LDEBUG
294F 4D 2950 76AF   474 KiB DEBUGGEE
9FFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
B000 4D 0008 0047    1136 B SD
B048 4D 0008 00CC   3.1 KiB S type 04 S_IRQSCODE
B115 4D C001 0100   4.0 KiB COMMAND
B216 4D B217 0019     400 B SEEKEXT
B230 4D 0000 05CE  23.2 KiB
B7FF 4D 0008 0800  32.0 KiB S type 30 S_EXCLDUMA
C000 4D C001 00A9   2.6 KiB COMMAND
C0AA 4D C001 1F54   125 KiB COMMAND
DFFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
F000 4D C001 096D  37.7 KiB COMMAND
F96E 4D C001 0090   2.2 KiB COMMAND
F9FF 5A 0008 0000       0 B S type 30 S_EXCLDUMA
&q
C:\>lh /l:2 ldebug /cdm;q
&dm
PSP: 2950
025C 4D 0008 001A     416 B S type 09 S_UPB
0277 4D 0008 0009     144 B S type 08 S_DPB
0281 4D 0008 0000       0 B SD
0282 4D 0283 26CC   155 KiB LDEBUG
294F 4D 2950 76AF   474 KiB DEBUGGEE
9FFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
B000 4D 0008 0047    1136 B SD
B048 4D 0008 00CC   3.1 KiB S type 04 S_IRQSCODE
B115 4D C001 0100   4.0 KiB COMMAND
B216 4D B217 0019     400 B SEEKEXT
B230 4D C001 05CE  23.2 KiB COMMAND
B7FF 4D 0008 0800  32.0 KiB S type 30 S_EXCLDUMA
C000 4D C001 00A9   2.6 KiB COMMAND
C0AA 4D 0000 1F54   125 KiB
DFFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
F000 4D C001 096D  37.7 KiB COMMAND
F96E 4D C001 0090   2.2 KiB COMMAND
F9FF 5A 0008 0000       0 B S type 30 S_EXCLDUMA
&q
C:\>lh /l:3 ldebug /cdm;q
&dm
PSP: 2950
025C 4D 0008 001A     416 B S type 09 S_UPB
0277 4D 0008 0009     144 B S type 08 S_DPB
0281 4D 0008 0000       0 B SD
0282 4D 0283 26CC   155 KiB LDEBUG
294F 4D 2950 76AF   474 KiB DEBUGGEE
9FFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
B000 4D 0008 0047    1136 B SD
B048 4D 0008 00CC   3.1 KiB S type 04 S_IRQSCODE
B115 4D C001 0100   4.0 KiB COMMAND
B216 4D B217 0019     400 B SEEKEXT
B230 4D C001 05CE  23.2 KiB COMMAND
B7FF 4D 0008 0800  32.0 KiB S type 30 S_EXCLDUMA
C000 4D C001 00A9   2.6 KiB COMMAND
C0AA 4D C001 1F54   125 KiB COMMAND
DFFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
F000 4D 0000 096D  37.7 KiB
F96E 4D C001 0090   2.2 KiB COMMAND
F9FF 5A 0008 0000       0 B S type 30 S_EXCLDUMA
&q
C:\>lh /l:4 ldebug /cdm;q
Illegal memory region 4 - ignored.
&dm
PSP: 2950
025C 4D 0008 001A     416 B S type 09 S_UPB
0277 4D 0008 0009     144 B S type 08 S_DPB
0281 4D 0008 0000       0 B SD
0282 4D 0283 26CC   155 KiB LDEBUG
294F 4D 2950 76AF   474 KiB DEBUGGEE
9FFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
B000 4D 0008 0047    1136 B SD
B048 4D 0008 00CC   3.1 KiB S type 04 S_IRQSCODE
B115 4D C001 0100   4.0 KiB COMMAND
B216 4D B217 0019     400 B SEEKEXT
B230 4D C001 05CE  23.2 KiB COMMAND
B7FF 4D 0008 0800  32.0 KiB S type 30 S_EXCLDUMA
C000 4D C001 00A9   2.6 KiB COMMAND
C0AA 4D C001 1F54   125 KiB COMMAND
DFFF 4D 0008 1000  64.0 KiB S type 30 S_EXCLDUMA
F000 4D C001 034A  13.1 KiB COMMAND
F34B 4D 0000 0622  24.5 KiB
F96E 4D C001 0090   2.2 KiB COMMAND
F9FF 5A 0008 0000       0 B S type 30 S_EXCLDUMA
&q
C:\>
```