### PR TITLE
Ptchsize and MacOS fix

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -180,10 +180,10 @@ if errorlevel 1 goto ende
 cd ..
 
 echo.
-echo Patching heap size to 8KB
+echo Patching heap size
 echo.
-utils\ptchsize.exe command.com +8KB
-utils\ptchsize.exe %CMD_NAME% +8KB
+utils\ptchsize.exe command.com %COMPILER% +6KB
+utils\ptchsize.exe %CMD_NAME% %COMPILER% +6KB
 
 if %WITH_UPX%x == x goto alldone
 if exist command.upx del command.upx >nul

--- a/build.sh
+++ b/build.sh
@@ -199,9 +199,9 @@ $MAKE all
 cd ..
 
 echo
-echo Patching heap size to 6KB
+echo Patching heap size
 echo
-utils/ptchsize.exe command.com +6KB
+utils/ptchsize.exe command.com $COMPILER +6KB
 
 if [ $WITH_UPX = "yes" ]; then
   rm -f command.upx

--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,11 @@ set -e
 WITH_UPX="no"
 SED=sed
 #workaround for Windows (set to binary mode)
-if [ "$(expr substr $(uname -s) 1 5)" == 'MINGW' ]; then
+if [ $(uname -s) == "Darwin" ]; then true
+	# Darwin expr does not support substr, so handle special here
+elif [ "$(expr substr $(uname -s) 1 5)" == 'MINGW' ]; then
     SED='sed -b'
 fi
-
 
 export SWAP=YES-DXMS-SWAP____________________
 # BEGIN Internal stuff for ska -- If one of these three commands


### PR DESCRIPTION
This merge request modifies ptchsize to require a command line argument for the compiler used to compile freecom. It also modifies the build.sh and build.bat scripts accordingly.

The additional heap is reduced to 6k again, as it should be sufficient?!?

build.sh is fixed to run on MacOS.