### PR TITLE
CI: Force lower case when unzipping

### DIFF
--- a/ci_prereq.sh
+++ b/ci_prereq.sh
@@ -62,23 +62,23 @@ cd ${HOME}/.dosemu/drive_c && (
   mkdir -p bin
 
   # Boot files
-  unzip -L -q ${HERE}/kernel.zip
+  unzip -LL -q ${HERE}/kernel.zip
   cp -p bin/kernl386.sys ./kernel.sys
-  unzip -L -q ${HERE}/freecom.zip
+  unzip -LL -q ${HERE}/freecom.zip
   cp -p bin/command.com ./command.com
   cp -p /usr/share/dosemu/dosemu2-cmds-0.3/c/fdconfig.sys .
 
   # Development files
-  unzip -L -q ${HERE}/djgpp_mk.zip
+  unzip -LL -q ${HERE}/djgpp_mk.zip
   cp -p devel/djgpp/bin/make.exe bin/.
-  unzip -L -q ${HERE}/upx.zip
+  unzip -LL -q ${HERE}/upx.zip
   cp -p devel/upx/upx.exe bin/.
   echo PATH to make and upx binaries is 'c:/bin'
 
-  unzip -L -q ${HERE}/nasm.zip
+  unzip -LL -q ${HERE}/nasm.zip
   echo PATH to nasm binary is 'c:/devel/nasm'
 
-  unzip -L -q ${HERE}/watcomc.zip
+  unzip -LL -q ${HERE}/watcomc.zip
   echo PATH to watcom binaries is 'c:/devel/watcomc/binw'
 
   # Turbo C


### PR DESCRIPTION
Sometimes DOS packages can have upper or mixed case filenames that Linux unzip doesn't recognise as needing downcasing.