### PR TITLE
support up to LASTDRIVE=32 (lDOS or patched MS-DOS v7)

### DIFF
--- a/shell/command.c
+++ b/shell/command.c
@@ -159,6 +159,14 @@ char switchar(void)
 }
 #endif
 
+unsigned isdrive(unsigned char cc) {
+  if (isalpha(cc))
+    return 1;
+  if ((cc - 'A') < 32)
+    return 1;
+  return 0;
+}
+
 void execute(char *first, char *rest, int lh_lf)
 {
   /*
@@ -177,7 +185,7 @@ void execute(char *first, char *rest, int lh_lf)
   assert(rest);
 
   /* check for a drive change (not for loadhigh/loadfix) */
-  if (!lh_lf && (strcmp(first + 1, ":") == 0) && isalpha(*first))
+  if (!lh_lf && (strcmp(first + 1, ":") == 0) && isdrive(*first))
   {
   	changeDrive(*first);
     return;

--- a/suppl/src/dfnpath.c
+++ b/suppl/src/dfnpath.c
@@ -75,9 +75,9 @@ char *dfnpath(int drive)
 	DBG_ENTER("dfnpath", Suppl_dfn)
 	DBG_ARGUMENTS( ("drive=%u ('%c')", drive, drive < 32? '.': drive) )
 
-	if(isupper(drive)) drive -= 'A' - 1;
-	else if(islower(drive)) drive -= 'a' - 1;
-	else if((unsigned)drive > 32) {
+	if (islower(drive)) drive -= 'a' - 'A';
+	if (drive >= 'A') drive -= 'A' - 1;
+	if ((unsigned)drive > 32) {
 		eno_set( ENODEV);
 		DBG_RETURN_S( 0)
 	}


### PR DESCRIPTION
Changing to a drive or running DIR with only a drive letter and colon didn't work. (DIR with drive letter, colon, backslash did work already.) Without this patch applied:

```
C:\>]:
Bad command or filename - "]:".
C:\>dir ]:
File not found. - ']:'
C:\>dir ]:\
 Volume in drive ] is SRDXMS 2.10
 Directory of ]:\

LDEBUG   COM        94,208  09-19-25  6:35p
         1 file(s)         94,208 bytes
         0 dir(s)         948,224 bytes free
```

With this patch applied:

```
C:\>]:
]:\>dir ]:
 Volume in drive ] is SRDXMS 2.10

 Directory of ]:\

LDEBUG   COM        94,208  09-19-25  6:35p
         1 file(s)         94,208 bytes
         0 dir(s)         948,224 bytes free
```