### PR TITLE
DIR: don't display invalid data with devices

### DIFF
--- a/cmd/dir.c
+++ b/cmd/dir.c
@@ -156,6 +156,9 @@
 #include <conio.h>
 #include <ctype.h>
 #include <dos.h>
+#ifndef FA_DEVICE
+#define FA_DEVICE 0x0040u
+#endif
 #include <io.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -1106,7 +1109,7 @@ static int dir_list(int pathlen
 
     if (cbreak)
       rv = E_CBreak;
-    else if(rv == E_None) {
+    else if (rv == E_None && file.ff_attrib != FA_DEVICE) {
 		if(file.ff_attrib & FA_DIREC) {
 			dircount++;
 		} else {


### PR DESCRIPTION
When doing `DIR NUL` findfirst will actually return success with an attribute indicating a device exists with that name. MS-DOS shows 'File not found' in this case, but FreeCOM (and also Comcom64) can display invalid data, so let's correct that. Since the required constant FA_DEVICE isn't always present in `dos.h`, let's define it when necessary.

[#181]

Before (C: is MFS, D: is FAT16):
~~~
C:\>dir nul
 Volume in drive C is IR DXXXXS C
 Directory of C:\

NUL                      0  10-30-25  6:55p
         1 file(s)              0 bytes
         0 dir(s)     49,839 Mega bytes free
C:\>d:

D:\>dir nul
 Volume in drive D has no label
 Volume Serial Number is 4A09-DBB4

 Directory of D:\

NUL                      0  10-30-25  6:55p
         1 file(s)              0 bytes
         0 dir(s)      42,698,752 bytes free
~~~

With patch (C: is MFS, D: is FAT16):
~~~
C:\>dir nul
 Volume in drive C is IR DXXXXS C
 Directory of C:\

File not found.

C:\>d:

D:\>dir nul
 Volume in drive D has no label
 Volume Serial Number is 4A09-DBB4
 Directory of D:\

File not found.
~~~